### PR TITLE
Proofreading

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,18 +1,18 @@
 # General Questions
 
-#### Q: What is a 'host' in cepl and why do I need one?
+#### Q: What is a 'host' in CEPL and why do I need one?
 
-Cepl, like opengl, doesnt dictate how you will manage windows or window events, it simply works with (and around) GL and the Gpu. So to work cepl needs something to provide the OpenGL context it will use. This is the job of the 'host'.
+CEPL, like OpenGL, doesn't manage windows or window events.  CEPL simply works with (and around) GL and the GPU.  In order to function, CEPL needs something to provide the OpenGL context it will use. This is the job of the 'host'.
 
-A host only needs to satisfy a very basic api so it's easy for you to make your own project a host. Or you can use the pre-made hosts like `cepl.sdl2`
+A host only needs to satisfy a very basic API, so it's easy for you to make your own project a host. Or you can use the pre-made hosts like `cepl.sdl2`
 
 # Cepl Systen Architecture Questions
 
 #### Q: Why are no hosts included by default? You could have them as part of this repo
 
-True, but I wanted to make it clear that hosts are totally seperate from cepl and that any project can host it if it satifies the cepl.host api.
+True, but I wanted to make it clear that hosts are totally seperate from CEPL and that any project can host it, if it satifies the cepl.host API.
 
 
 #### Q: Why are 'hosts' called 'hosts' and not something like 'backends'?
 
-To me this gave the impression that cepl was a frontend, this feels wrong as cepl is just a tool, the frontend to you application is yours to define.
+To me this implies that cepl is a frontend.  This feels wrong as CEPL is just a tool; the frontend to you application is yours to define.

--- a/FAQ.md
+++ b/FAQ.md
@@ -6,7 +6,7 @@ CEPL, like OpenGL, doesn't manage windows or window events.  CEPL simply works w
 
 A host only needs to satisfy a very basic API, so it's easy for you to make your own project a host. Or you can use the pre-made hosts like `cepl.sdl2`
 
-# Cepl Systen Architecture Questions
+# CEPL System Architecture Questions
 
 #### Q: Why are no hosts included by default? You could have them as part of this repo
 
@@ -15,4 +15,4 @@ True, but I wanted to make it clear that hosts are totally seperate from CEPL an
 
 #### Q: Why are 'hosts' called 'hosts' and not something like 'backends'?
 
-To me this implies that cepl is a frontend.  This feels wrong as CEPL is just a tool; the frontend to you application is yours to define.
+To me this implies that CEPL is a frontend.  This feels wrong as CEPL is just a tool; the frontend to you application is yours to define.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ## CEPL (Code Evaluate Play Loop) - [Beta]
 
-CEPL is a lispy and REPL friendly library for working with OpenGL.
+CEPL is a lispy and REPL-friendly Common Lisp library for working with OpenGL.
 
-It's definition of success is if the user feels like GPU programming had always been part of the languages standard.
+Its definition of success is making the user feel that GPU programming has always been part of the languages standard.
 
-The usual approach to using it is to start it at the beginning of your lisp session and leave it open for the duration of your work. You can then treat the window it creates as just another output for your graphics, analogous to how `*standard-output*` is treated for text.
+The usual approach to using CEPL is to start it at the beginning of your Lisp session and leave it open for the duration of your work. You can then treat the window it creates as just another output for your graphics, analogous to how `*standard-output*` is treated for text.
 
-CEPL is in beta. The API is close to what it needs to be but there are still many bugs to fix, features to add and experiences to smooth out.
+CEPL is in beta. The API is close to what it needs to be but there are still many bugs to fix, features to add, and experiences to smooth out.
 
 See the [cepl.examples repository](https://github.com/cbaggers/cepl.examples) for some examples of how CEPL can be used
 
@@ -18,7 +18,7 @@ Currently we have full documentation of every exported symbol in the CEPL packag
 
 Guides will be provided in future, however these take much longer to write.
 
-I can also be reached by my email (techsnuffle [at] gmail · com) and sometimes on #lispgames IRC. Come to #lispgames anyway though, theres some lovely folks, all lispy dialects welcome!
+I can also be reached by my email (techsnuffle [at] gmail · com) and sometimes on #lispgames IRC. Come to #lispgames anyway though, there are some lovely folks, all lispy dialects welcome!
 
 ### Requirements
 
@@ -39,29 +39,29 @@ All of the following will be downloaded automatically by quicklisp
 
 #### C Library dependency
 
-CEPL uses OpenGL so you need to make sure this is available on your machine. Installing your GPU drivers will usually handle this.
+CEPL uses OpenGL so you need to make sure it is available on your machine. Installing your GPU drivers will usually handle this.
 
 
 #### CEPL's Host
 
-CEPL abstracts working with OpenGL but is not responsible for creating a window or GL context, this is handled by a `Host`. Right now the only supported host is `SDL2`, the system to load is called `cepl.sdl2`, you can find it here: [cepl.sdl2](https://github.com/cbaggers/cepl.sdl2)
+CEPL abstracts working with OpenGL but is not responsible for creating a window or GL context; this is handled by a `Host`. Right now the only supported host is `SDL2`; the system to load is called `cepl.sdl2`, you can find it here: [cepl.sdl2](https://github.com/cbaggers/cepl.sdl2)
 
 
 ### Getting Started
 
-_Note:_ On `Windows` and `OSX` and are using `slime` you may want to add the code specifed in `docs/single-thread-swank.md` to your emacs config file, and use the command `slime-style` which will start `slime` in a more OpenGL friendly mode. Then follow the rest of this as usual.
+_Note:_ On `Windows` and `OSX`, `slime` users may want to add the code specifed in `docs/single-thread-swank.md` to their Emacs config file, and use the command `slime-style` which will start `slime` in a more OpenGL friendly mode. Then follow the rest of this as usual.
 
 To load CEPL and the default host (`sdl2`) do the following:
 
 - `(ql:quickload :cepl.sdl2)`
 - `(cepl:repl)`
 
-You should see an empty window appear, OpenGL is now initialized and you can use CEPL as you like.
+You should see an empty window appear, OpenGL is now initialized, and you can use CEPL as you like.
 
 
 ### Making a CEPL Project
 
-The best way to get started is to make a new project that uses CEPL. Do the following in your repl to get set up:
+The best way to get started is to make a new project that uses CEPL. Do the following in your REPL to get set up:
 
 - First, run `(ql:quickload :cepl)`
 - Then run `(ql:quickload :quickproject)`. Cepl uses this to create a lisp project using its own templates
@@ -71,7 +71,7 @@ The best way to get started is to make a new project that uses CEPL. Do the foll
  - [skitter](https://github.com/cbaggers/skitter) for handling input and events
  - [cepl.devil](https://github.com/cbaggers/cepl.devil) for loading images
 
-You are now ready to get started, simply run:
+You are now ready to get started. Simply run:
 - `(ql:quickload "my-proj")`
 - `(in-package :my-proj)`
 - and finally (if you havent already) `(cepl:repl)`
@@ -79,4 +79,4 @@ You are now ready to get started, simply run:
 
 #### Windows C Library Hack
 
-If you are having issues getting the c libraries to load and just need to rule out whether lisp can find them, try putting them in the same folder as the lisp exe. For example `C:\Program Files\sbcl\`.
+If you are having issues getting the C libraries to load and just need to rule out whether Lisp can find them, try putting them in the same folder as the lisp exe. For example `C:\Program Files\sbcl\`.

--- a/docs/000 - intro.md
+++ b/docs/000 - intro.md
@@ -1,32 +1,29 @@
 # Cepl - (Alpha)
 
-Cepl is a sane interface to the modern opengl api.
+Cepl is a sane interface to the modern OpenGL API.
 
 ### OpenGL Background
 
-OpenGL gets a bad rap for its api, and for good reason, it is actually 2 (pretty much) incompatible apis in one box.
+OpenGL gets a bad rap for its API, and for good reason: it is actually two (pretty much) incompatible API's in one box.
 
-The first api is the old fixed function pipeline and the other is the modern shader based pipeline. The ugly thing is that these apis often reuse functions even when the behaviour underneath is very different. This makes for a very fustrating experience.
+The first API is the old fixed-function pipeline, and the second is the modern shader-based pipeline. The ugly thing is that these APIs often reuse function names, even when the behaviour underneath is very different. This makes for a very fustrating experience.
 
-The belief help by Cepl is that there is an good api in there, it's just very well hidden :)
+The belief held by Cepl is that there is a good API in OpenGL, it's just very well hidden :)
 
 ### Cepl's Goals
 
-- Make a sane interface to the modern opengl api.
-- Make working opengl lispy & repl friendly
-- Do the above without wasting performance (see perf section below)
+- Make a sane interface to the modern OpenGL API.
+- Make working with OpenGL lispy & repl friendly
+- Do the above without losing performance (see Performance section below)
 
 ### Performance
 
-The third and second goals can often be at odds in a project like this. We want to get the abosulte maximum power that it's possible to get out of common lisp *but* we also adore the repl and the power it brings.
+The third and second goals can often be at odds with each other in a project like this. We want to get the absolute maximum performance out of Common Lisp, *but* we also adore the repl and the power it brings.
 
-The goal therefore is to always have a codepath that is optimized as hard as we can (whilst being as pleasant as possible) and then in those situations where it can't be made repl friendly we have a more generic code path that sacrifices a bit of performace for coder-experience.
+The goal, therefore, is to always have a codepath that is optimized as hard as possible (whilst being as pleasant as possible). In those situations where the abstractions are not repl-friendly, we create a more generic codepath that sacrifices a bit of performance for coder-experience.  This should be minimized. Very high levels of abstractions tend to be geared to a certain aproach or technique, and those are best kept in a seperate library that depends on Cepl.
 
-There should be as little of the later as possible though. Very high level of abstractions tend to be geared to a certain aproach or technique and those things are best kept in a seperate library that depends on Cepl.
+### Bugs and Unsupported Features
 
+Any commonly used features of modern OpenGL that are either impossible or prohibitively slow in Cepl are likely to be considered a bug.
 
-### Can I do 'x'?
-
-If there is a feature in modern opengl that is good practice and is either impossible or prohibitively slow then 95% of the time that is considered a bug.
-
-A goal is that each thing people fine that isnt going to be supported must be recorded in the [wont-support.md](./wont-support.md) file and be justified. We can't guarentee that the reason will be satisfying but it should be in keeping with the project.
+Another goal is to document all unsupported features in [wont-support.md](./wont-support.md) along with the justification for not supporting it. We can't guarentee that the reason will be satisfying, but it should be in keeping with the project.

--- a/docs/000 - intro.md
+++ b/docs/000 - intro.md
@@ -1,6 +1,6 @@
-# Cepl - (Alpha)
+# CEPL - (Alpha)
 
-Cepl is a sane interface to the modern OpenGL API.
+CEPL is a sane interface to the modern OpenGL API.
 
 ### OpenGL Background
 
@@ -8,9 +8,9 @@ OpenGL gets a bad rap for its API, and for good reason: it is actually two (pret
 
 The first API is the old fixed-function pipeline, and the second is the modern shader-based pipeline. The ugly thing is that these APIs often reuse function names, even when the behaviour underneath is very different. This makes for a very fustrating experience.
 
-The belief held by Cepl is that there is a good API in OpenGL, it's just very well hidden :)
+The belief held by CEPL is that there is a good API in OpenGL, it's just very well hidden :)
 
-### Cepl's Goals
+### CEPL's Goals
 
 - Make a sane interface to the modern OpenGL API.
 - Make working with OpenGL lispy & repl friendly
@@ -20,10 +20,10 @@ The belief held by Cepl is that there is a good API in OpenGL, it's just very we
 
 The third and second goals can often be at odds with each other in a project like this. We want to get the absolute maximum performance out of Common Lisp, *but* we also adore the repl and the power it brings.
 
-The goal, therefore, is to always have a codepath that is optimized as hard as possible (whilst being as pleasant as possible). In those situations where the abstractions are not repl-friendly, we create a more generic codepath that sacrifices a bit of performance for coder-experience.  This should be minimized. Very high levels of abstractions tend to be geared to a certain aproach or technique, and those are best kept in a seperate library that depends on Cepl.
+The strategy, therefore, is to always have a codepath that is optimized as hard as possible (whilst being as pleasant as possible). In those situations where the abstractions are not repl-friendly, we create a more generic codepath that sacrifices a bit of performance for coder-experience. This should be minimized. Very high levels of abstractions tend to be geared to a certain aproach or technique, and those are best kept in a seperate library that depends on CEPL.
 
 ### Bugs and Unsupported Features
 
-Any commonly used features of modern OpenGL that are either impossible or prohibitively slow in Cepl are likely to be considered a bug.
+Any commonly used features of modern OpenGL that are either impossible or prohibitively slow in CEPL are likely to be considered a bug.
 
 Another goal is to document all unsupported features in [wont-support.md](./wont-support.md) along with the justification for not supporting it. We can't guarentee that the reason will be satisfying, but it should be in keeping with the project.

--- a/docs/001 - Into the code.md
+++ b/docs/001 - Into the code.md
@@ -1,80 +1,66 @@
 # Blam! Code
 
-Rather than mess around with a lot more introductions let's just look at a simple code example, and use it as an index to the first chapters of this documentation. Don't expect to understand this code straight away; it will take a little getting used to.
-
-A bunch of lines have comments that look like this: `[x] some topic`, where `x` is some number; look below the code to find the relevent information for that comment.
+Rather than mess around with a lot more introductions let's just look at a simple code example. Don't expect to understand the details right away; it will take a little getting used to.
 
 Below is the standard OpenGL version of 'hello world', a colored triangle.
 
 ```
 (in-package :cepl)
+;;;; cepl-learn.lisp
+
+(in-package #:cepl-learn)
 
 (defparameter *array* nil)
 (defparameter *stream* nil)
 (defparameter *running* nil)
 
+;; Lisp data for triangle vertices
 (defparameter *triangle-data*
    (list (list (v!  0.5 -0.36 0) (v! 0 1 0 1))
          (list (v!    0   0.5 0) (v! 1 0 0 1))
          (list (v! -0.5 -0.36 0) (v! 0 0 1 1))))
 
-;; [1] defining a struct that works on gpu and cpu
+;; A struct that works on gpu and cpu
 (defstruct-g pos-col 
   (position :vec3 :accessor pos)
   (color :vec4 :accessor col))
 
-;; [7] defining a function that works on the gpu
+;; A GPU vertex shader using a Lisp syntax (see Varjo)
 (defun-g vert ((vert pos-col))
   (values (v! (pos vert) 1.0)
           (col vert)))
 
-;; [8] and another function
+;; A GPU fragment shader 
 (defun-g frag ((color :vec4))
   color)
 
-;; [9] composing those gpu functions into a pipeline
+;; Composing those gpu functions into a pipeline
 (def-g-> prog-1 ()
     vert frag)
 
-;; here is what we do each frame
+;; Here is what we do each frame:
 (defun step-demo ()
-  (step-host) ;; [3]
-  (update-repl-link) ;; [4]
-  (clear) ;; [5]
-  (map-g #'prog-1 *stream*) ;; [6]
-  (swap)) ;; [10]
+  (step-host)        ;; Advance the host environment frame
+  (update-repl-link) ;; Keep the REPL responsive while running
+  (clear)            ;; Clear the drawing buffer 
+  (map-g #'prog-1 *stream*) ;; Render data from GPU datastream
+  (swap))            ;; Display newly rendered buffer 
 
 
 (defun run-loop ()
   (setf *running* t
-        *array* (make-gpu-array *triangle-data* :element-type 'pos-col) ;; [0]
-        *stream* (make-buffer-stream *array*)) ;; [2]
+	;; Create a gpu array from our Lisp vertex data
+        *array* (make-gpu-array *triangle-data* :element-type 'pos-col)
+	;; Create a GPU datastream
+        *stream* (make-buffer-stream *array*))
+  ;; continue rendering frames until *running* is set to nil
   (loop :while (and  *running*
 		     (not (shutting-down-p))) :do
      (continuable (step-demo))))
 
 (defun stop-loop ()
   (setf *running* nil))
+
 ```
 
-Phew! That was a pile of stuff. Here is a quick summary of what will happen when you compile the code below and invoke `(run-loop)`:
-
-#### First:
-
-`#:run-loop` will set `*running*` to `t`. When `*running*` is set to `nil` we will stop the main loop.
-
-#### [0] Make the data for our triangle on the gpu
-
-On this line we create an array on the gpu to hold the data for our triangle.
-
-We use lisp data that was defined in `*triangle-data*` and the `pos-col` type defined in `[1]`
-
-To read up on where data can live in Cepl see [chapter 002 - memory](./chapter 002 - memory.md)
-
-`[1]` defstruct-g is a way of defining a struct type that can be used in `c-arrays` and `gpu-arrays`
-
-
-
-
-- we make a buffer-stream from the the gpu-array. We will render by running our pipeline over the data in this stream
-- we run the main loop which will call `#'step-demo` until `*running*` is `nil`
+Phew! That was a pile of stuff. Follow the comments to get an understanding of what will happen and invoke `(run-loop)`.

--- a/docs/001 - Into the code.md
+++ b/docs/001 - Into the code.md
@@ -1,10 +1,10 @@
 # Blam! Code
 
-Rather than mess around with a lot more introduction let's just look at a simple code example and use it as an index to the first chapters of this documentation. Don't expect to understand this code straight away, it will take a little getting used to.
+Rather than mess around with a lot more introductions let's just look at a simple code example, and use it as an index to the first chapters of this documentation. Don't expect to understand this code straight away; it will take a little getting used to.
 
-A bunch of lines have comments that look like this `[x] some topic` where `x` is some number, look below the code to find the relevent information for that comment.
+A bunch of lines have comments that look like this: `[x] some topic`, where `x` is some number; look below the code to find the relevent information for that comment.
 
-Below we will do the standard OpenGL version of 'hello world' and draw a colored triangle.
+Below is the standard OpenGL version of 'hello world', a colored triangle.
 
 ```
 (in-package :cepl)
@@ -12,13 +12,14 @@ Below we will do the standard OpenGL version of 'hello world' and draw a colored
 (defparameter *array* nil)
 (defparameter *stream* nil)
 (defparameter *running* nil)
+
 (defparameter *triangle-data*
    (list (list (v!  0.5 -0.36 0) (v! 0 1 0 1))
          (list (v!    0   0.5 0) (v! 1 0 0 1))
          (list (v! -0.5 -0.36 0) (v! 0 0 1 1))))
 
 ;; [1] defining a struct that works on gpu and cpu
-(defstruct-g pos-col ()
+(defstruct-g pos-col 
   (position :vec3 :accessor pos)
   (color :vec4 :accessor col))
 
@@ -32,8 +33,8 @@ Below we will do the standard OpenGL version of 'hello world' and draw a colored
   color)
 
 ;; [9] composing those gpu functions into a pipeline
-(defpipeline prog-1 ()
-    (g-> #'vert #'frag))
+(def-g-> prog-1 ()
+    vert frag)
 
 ;; here is what we do each frame
 (defun step-demo ()
@@ -43,26 +44,28 @@ Below we will do the standard OpenGL version of 'hello world' and draw a colored
   (map-g #'prog-1 *stream*) ;; [6]
   (swap)) ;; [10]
 
+
 (defun run-loop ()
   (setf *running* t
         *array* (make-gpu-array *triangle-data* :element-type 'pos-col) ;; [0]
         *stream* (make-buffer-stream *array*)) ;; [2]
-  (loop :while *running* :do (continuable (step-demo))))
+  (loop :while (and  *running*
+		     (not (shutting-down-p))) :do
+     (continuable (step-demo))))
 
 (defun stop-loop ()
   (setf *running* nil))
-
 ```
 
-Phew! that was a pile of stuff. Here is a quick summary of what will happen when you compile the code below and call `(run-loop)`:
+Phew! That was a pile of stuff. Here is a quick summary of what will happen when you compile the code below and invoke `(run-loop)`:
 
-#### First things
+#### First:
 
-`#'run-loop` will set `*running*` to `t`. When `*running*` is set to `nil` we will stop the main loop
+`#:run-loop` will set `*running*` to `t`. When `*running*` is set to `nil` we will stop the main loop.
 
 #### [0] Make the data for our triangle on the gpu
 
-On this line we create and array on the gpu to hold the data for our triangle.
+On this line we create an array on the gpu to hold the data for our triangle.
 
 We use lisp data that was defined in `*triangle-data*` and the `pos-col` type defined in `[1]`
 

--- a/docs/001 - Into the code.md
+++ b/docs/001 - Into the code.md
@@ -3,12 +3,8 @@
 Rather than mess around with a lot more introductions let's just look at a simple code example. Don't expect to understand the details right away; it will take a little getting used to.
 
 Below is the standard OpenGL version of 'hello world', a colored triangle.
-
-```
+```lisp
 (in-package :cepl)
-;;;; cepl-learn.lisp
-
-(in-package #:cepl-learn)
 
 (defparameter *array* nil)
 (defparameter *stream* nil)

--- a/docs/002 - memory.md
+++ b/docs/002 - memory.md
@@ -2,34 +2,30 @@
 
 ### Where's my data?
 
-With Cepl your data can exist in 3 different places:
+With CEPL data can exist in three different places:
 
 - lisp memory - The regular lisp data in your program. This get's GC'd (garbage collected)
 - c memory - Data stored in block of cffi memory. This does not get GC'd
 - gpu memory - Data stored on the GPU. This does not get GC'd
 
-A lot of work done in cepl is about making moving data between these places easy.
+CEPL makes moving data between these places easy.
 
 ### GC
 
-Garbage collection is our friend in lisp. It let's us use our repls for experimental bliss and makes possible the kinds of data structures that would be a knightmare to keep in order without a very special data ownership model.
+Garbage collection is our friend in lisp. GC facilitates the use our REPLs for experimental bliss and allows data structures that would be a nightmare to maintain otherwise.
 
-However in realtime graphics the GC *can* be a problem. One of the things we end up working very hard for is a stable frame rate which makes spikes in GC activity a problem. It clearly is possible to have a GC and make games but the core system have to be written sensibly to ensure they arent adding load.
+However, in realtime graphics the GC *can* be a problem. Stable frame rate is a major requirement, and spikes in GC activity can cause problems. It is clearly possible to have a GC and make games, but the core systems have to be written sensibly to ensure they aren't adding load.
 
-On top of this, communication with the gpu can be very expensive if done at the wrong time. Deciding to free a bunch of gpu memory without being very aware of the current render state is a recipe for disaster.
+Communication with the GPU at the wrong time can be very expensive. Freeing GPU memory used by the current render state is a recipe for disaster.  To this end, by default, none of the data in c-memory or gpu-memory is GC'd. This obviously means you need to free this data yourself, or you will end up with memory leaks.
 
-To this end, by default, none of the data in c-memory or gpu-memory is GC'd. This obviously means you need to free this data yourself or you end up with memory leaks.
-
-We say by default as there are certain times you don't mind paying the cost. For example when you are playing with ideas in the repl. To this end we are looking into ways of providing this without compromising any performance in the rest of cepl. This is WIP so this doco will be updated when that is in place.
+We say "by default" as there are certain times you may not mind paying the cost. For example, when you are playing with ideas in the REPL. To this end we are exploring ways of providing this capability without compromising any performance in the rest of CEPL. This is WIP so this doc will be updated when that is in place.
 
 ### #'free and #'free-*
 
 To release memory we have two options, firstly we can use the generic function #'free as in
-
 ```
 (free some-cepl-data)
 ```
-
 However you may not want to pay the dispatch cost in performance critical code, so there are a number of `free-*` functions (e.g. #'free-c-array #'free-gpu-array etc). These specific functions will be covered in their respective chapters.
 
 ### #'pull-g & #'push-g

--- a/docs/002 - memory.md
+++ b/docs/002 - memory.md
@@ -4,7 +4,7 @@
 
 With CEPL data can exist in three different places:
 
-- lisp memory - The regular lisp data in your program. This get's GC'd (garbage collected)
+- lisp memory - The regular lisp data. This get's GC'd (garbage collected)
 - c memory - Data stored in block of cffi memory. This does not get GC'd
 - gpu memory - Data stored on the GPU. This does not get GC'd
 
@@ -12,13 +12,13 @@ CEPL makes moving data between these places easy.
 
 ### GC
 
-Garbage collection is our friend in lisp. GC facilitates the use our REPLs for experimental bliss and allows data structures that would be a nightmare to maintain otherwise.
+Garbage collection is our friend in lisp. GC facilitates the use our REPLs for experimental bliss and allows for data structures that would be a nightmare to maintain otherwise.
 
-However, in realtime graphics the GC *can* be a problem. Stable frame rate is a major requirement, and spikes in GC activity can cause problems. It is clearly possible to have a GC and make games, but the core systems have to be written sensibly to ensure they aren't adding load.
+However, in realtime graphics, the GC *can* be a problem. Stable frame rate is a major requirement, and spikes in GC activity can cause problems. It is clearly possible to have a GC and make games, but the core systems have to be written sensibly to ensure they aren't adding load.
 
-Communication with the GPU at the wrong time can be very expensive. Freeing GPU memory used by the current render state is a recipe for disaster.  To this end, by default, none of the data in c-memory or gpu-memory is GC'd. This obviously means you need to free this data yourself, or you will end up with memory leaks.
+Communication with the GPU at the wrong time can be very expensive. Freeing GPU memory used by the current render state is a recipe for disaster.  To this end, by default, none of the data in c-memory or gpu-memory is GC'd. This obviously means we need to free this data ourselves, or end up with memory leaks.
 
-We say "by default" as there are certain times you may not mind paying the cost. For example, when you are playing with ideas in the REPL. To this end we are exploring ways of providing this capability without compromising any performance in the rest of CEPL. This is WIP so this doc will be updated when that is in place.
+We say "by default" as there are certain times GC may be worth the cost. For example, when we are playing with ideas in the REPL: interactive environments tend to accumulate garbage. To this end, we are exploring ways of providing this capability without compromising any performance in the rest of CEPL. This is work in progress, so this document will be updated as changes are made.
 
 ### #'free and #'free-*
 
@@ -26,17 +26,16 @@ To release memory we have two options, firstly we can use the generic function #
 ```
 (free some-cepl-data)
 ```
-However you may not want to pay the dispatch cost in performance critical code, so there are a number of `free-*` functions (e.g. #'free-c-array #'free-gpu-array etc). These specific functions will be covered in their respective chapters.
+However, in critical code, the dispatch cost may be considerable; there are a number of `free-*` functions (e.g. #'free-c-array #'free-gpu-array etc) that operate on specific types directly. These functions will be covered in their respective chapters.
 
 ### #'pull-g & #'push-g
 
-These are two very helpful generic functions that let you move data between lisp, c-memory &
-gpu-memory with ease!
+These are two very helpful generic functions that move data between Lisp, c-memory & gpu-memory with ease:
 
-`push-g` will take a lisp array or lisp list and push the data into a c-array or a gpu-array (dont worry if you dont know what these are yet)
+`push-g` takes a Lisp array or Lisp list and pushes the data into a c-array or a gpu-array;
 
-`pull-g` will pull data from c-array ＆ gpu-arrays and bring it back into lisp.
+`pull-g` pulls data from c-array or gpu-arrays and brings it back into lisp.
 
-Obviously the generic dispatch and working out how to upload the data to a given target takes time, so these are generally used in non performance critical places, like the repl!
+Obviously, the generic dispatch and working out how to upload the data to a given target take time, so these are generally used in non performance critical places, like the REPL.
 
-There is also a bit more to this but we will revisit these in a later chapter.
+There is more to this, but we will revisit this topic in a later chapter.

--- a/docs/003 - types.md
+++ b/docs/003 - types.md
@@ -1,71 +1,71 @@
-# Types in Cepl
+# Types in CEPL
 
 ### Back to the Bytes
 
-Types in Cepl are a lot more akin to the primitive types in languages like C, in that they have a one to one mapping to the byte layout in memory.
-
-This is unlike the usual state of affairs in lisp where we let the implementation decide how memory is laid out.
+Types in CEPL have a one to one mapping to the byte layout in memory, much like the primitive types in languages such as C.  This is unlike the usual state of affairs in Lisp where we let the implementation decide how memory is laid out.
 
 ### Where we use these
 
-We use these types whenever we want to work with data-structures in C or GPU memory.
+We use these types to work with data-structures in C or GPU memory.
 
-### How does these map to lisp types?
+### How do these map to lisp types?
 
-All the 'C' memory is being handled through cffi so all of the mappings are defined through that system.
+All the C memory is being handled through cffi, so all of the mappings are defined through that system.
 
 ### What's with the naming?
 
-If you have already had a peek below you will have seen many keywords being used as names. This is a pattern used by cffi for its in-built types and when we added the additional core graphics types (vec3, mat4 etc) it felt bad when they were plain symbols (as very quickly you get used to keyword meaning in-built type).
+If you have already had a peek below, you will have seen many keywords being used as names. This is a pattern used by cffi for its in-built types, and when we added the additional core graphics types (vec3, mat4 etc), we continued using keywords for consistency.  You will quickly get used to keywords repersenting in-built types.
 
-So the rule has become that that core types have optional keyword names and all users defined types have regular symbols names (just like cffi)
+The rule is that core types have optional keyword names, and all user-defined types have regular symbols names, just like cffi.
 
-### Cepl's basic types
+### CEPL's basic types
 
-So without further ado, lets look at each type, the size in bytes and the lisp types it maps to.
+So without further ado, lets look at each type, the size in bytes, and the lisp types it maps to.
 
-name         size in bytes     component-type     lisp-type
-:vec2        8                 :float             (simple-array single-float (2))
-:vec3        12                :float             (simple-array single-float (2))
-:vec4        16                :float             (simple-array single-float (2))
-:ivec2       8                 :int               (simple-array integer (2)) *
-:ivec3       12                :int               (simple-array integer (2)) *
-:ivec4       16                :int               (simple-array integer (2)) *
-:uvec2       8                 :uint              (simple-array unsigned-integer (2)) *
-:uvec3       12                :uint              (simple-array unsigned-integer (2)) *
-:uvec4       16                :uint              (simple-array unsigned-integer (2)) *
+| name        | bytes | component-type |    lisp-type |
+|:------------|------:|:---------------|:-------------|
+| :vec2       |  8    | :float         | (simple-array single-float (2)) |
+| :vec3       |  12   | :float         | (simple-array single-float (2)) |
+| :vec4       |  16   | :float         | (simple-array single-float (2)) |
+| :ivec2      |  8    | :int           | (simple-array integer (2)) * |
+| :ivec3      |  12   | :int           | (simple-array integer (2)) * |
+| :ivec4      |  16   | :int           | (simple-array integer (2)) * |
+| :uvec2      |  8    | :uint          | (simple-array unsigned-integer (2)) * |
+| :uvec3      |  12   | :uint          | (simple-array unsigned-integer (2)) * |
+| :uvec4      |  16   | :uint          | (simple-array unsigned-integer (2)) * |
+| :uint8-vec2 |  2    | :uint8         | (simple-array (integer 0 255) (2)) * |
+| :uint8-vec3 |  3    | :uint8         | (simple-array (integer 0 255) (2)) * |
+| :uint8-vec4 |  4    | :uint8         | (simple-array (integer 0 255) (2)) * |
+| :int8-vec2  |  2    | :int8          | (simple-array (integer -127 128) (2)) * |
+| :int8-vec3  |  3    | :int8          | (simple-array (integer -127 128) (2)) * |
+| :int8-vec4  |  4    | :int8          | (simple-array (integer -127 128) (2)) * |
+| :mat2       | 16    | :float         | (simple-array single-float (4))  |
+| :mat3       | 36    | :float         | (simple-array single-float (9)) |
+| :mat4       | 64    | :float         | (simple-array single-float (16)) |
 
-:uint8-vec2  2                 :uint8             (simple-array (integer 0 255) (2)) *
-:uint8-vec3  3                 :uint8             (simple-array (integer 0 255) (2)) *
-:uint8-vec4  4                 :uint8             (simple-array (integer 0 255) (2)) *
-:int8-vec2   2                 :int8              (simple-array (integer -127 128) (2)) *
-:int8-vec3   3                 :int8              (simple-array (integer -127 128) (2)) *
-:int8-vec4   4                 :int8              (simple-array (integer -127 128) (2)) *
-
-:mat2        16                :float             (simple-array single-float (4))
-:mat3        36                :float             (simple-array single-float (9))
-:mat4        64                :float             (simple-array single-float (16))
-
-To be 100% accurate I have to say, that for all the types with `*` at the end, the type returned is actually implementation specific. But practically you get the idea :)
+To be 100% accurate I have to say, that for all the types with `*` at the end, the type returned is actually implementation specific. But you get the idea :)
 
 See the [cffi documentation for details](https://common-lisp.net/project/cffi/manual/cffi-manual.html#Built_002dIn-Types)
 
 ### Supported cffi types
-Of course we also support some of the cffi types. For completeness I'll list those here:
 
-:short
-:ushort (also called :unsigned-short )
-:int
-:uint  (also called :unsigned-int)
-:float
-:double
+Of course we also support some of the cffi types. For completeness here is a list:
 
-We will soon also support `:int8` & `:uint8`
+| name |
+|:-----|
+| :short |
+| :ushort (also called :unsigned-short ) |
+| :int |
+| :uint  (also called :unsigned-int) |
+| :float |
+| :double |
 
-### No no limits
+Soon we will also support `:int8` & `:uint8`
 
-Of course if this was all we could use it would be a bit limiting. Luckily we can have arrays of this data and also user defined structs, which is what we will look at in the next chapter.
+### No limits
+
+Of course, if this was all we could use, it would be a bit limiting. Luckily, we can have arrays of this data as well as user defined structs (which is what we will look at in the next chapter).
 
 ### p.s
 
-For the sake of brevity we will refer to *all the above types* PLUS *all cepl structs* PLUS *all cepl arrays of these types* using the phrase 'cepl compatible types'
+For the sake of brevity we will refer to *all the above types* PLUS *all cepl structs* PLUS *all cepl arrays of these types* using the phrase 'CEPL-compatible types'

--- a/docs/003 - types.md
+++ b/docs/003 - types.md
@@ -10,13 +10,13 @@ We use these types to work with data-structures in C or GPU memory.
 
 ### How do these map to lisp types?
 
-All the C memory is being handled through cffi, so all of the mappings are defined through that system.
+All the C memory is being handled through CFFI, so all of the mappings are defined through that system.
 
 ### What's with the naming?
 
-If you have already had a peek below, you will have seen many keywords being used as names. This is a pattern used by cffi for its in-built types, and when we added the additional core graphics types (vec3, mat4 etc), we continued using keywords for consistency.  You will quickly get used to keywords repersenting in-built types.
+If you have already had a peek below, you will have seen many keywords being used as names. This is a pattern used by CFFI for its in-built types, and when we added the additional core graphics types (vec3, mat4 etc), we continued using keywords for consistency.  You will quickly get used to keywords repersenting in-built types.
 
-The rule is that core types have optional keyword names, and all user-defined types have regular symbols names, just like cffi.
+The rule is that core types have optional keyword names, and all user-defined types have regular symbols names, just like CFFI.
 
 ### CEPL's basic types
 
@@ -45,13 +45,13 @@ So without further ado, lets look at each type, the size in bytes, and the lisp 
 
 To be 100% accurate I have to say, that for all the types with `*` at the end, the type returned is actually implementation specific. But you get the idea :)
 
-See the [cffi documentation for details](https://common-lisp.net/project/cffi/manual/cffi-manual.html#Built_002dIn-Types)
+See the [CFFI documentation for details](https://common-lisp.net/project/cffi/manual/cffi-manual.html#Built_002dIn-Types)
 
-### Supported cffi types
+### Supported CFFI types
 
-Of course we also support some of the cffi types. For completeness here is a list:
+Of course we also support some of the CFFI types. For completeness here is a list:
 
-| name |
+|      |
 |:-----|
 | :short |
 | :ushort (also called :unsigned-short ) |

--- a/docs/004 - user-defined-structs.md
+++ b/docs/004 - user-defined-structs.md
@@ -4,7 +4,7 @@ Laying out GPU data in memory is one of the really tricky parts of working with 
 
 ### Defining
 
-You create these using `defstruct-g`, so lets look at an example right now:
+`defstruct-g` is used to create these special structs, so lets look at an example right now:
 
 ```
      (defstruct-g our-data

--- a/docs/004 - user-defined-structs.md
+++ b/docs/004 - user-defined-structs.md
@@ -5,8 +5,7 @@ Laying out GPU data in memory is one of the really tricky parts of working with 
 ### Defining
 
 `defstruct-g` is used to create these special structs, so lets look at an example right now:
-
-```
+```lisp
      (defstruct-g our-data
        (position :vec3)
        (val :int :accessor val))
@@ -15,8 +14,7 @@ Laying out GPU data in memory is one of the really tricky parts of working with 
 This should seem familiar if you have used Common Lisp's structs.  You provide a name, options (if you need them), and the definitions for the slots. The slots are mostly what we are interested in, so let's look at them.  
 
 The format for a slot is:
-
-```
+```lisp
      (slot-name slot-type)
 
      -or-
@@ -27,8 +25,7 @@ The format for a slot is:
 ### Gimme one!
 
 The first example above makes a slot of the given type (which must be a CEPL-compatible type). As with regular Lisp structs, to make an instance of `our-data` type use the `make-our-data` function, passing in values with the keyword arguments. For example:
-
-```
+```lisp
      (defvar x (make-our-data :position (v! 1 2 3) :val 5))
 ```
 
@@ -57,8 +54,7 @@ Also note that I said "on the cpu". As we shall see, our shaders are statically 
 ### Options
 
 Let's look at another example struct:
-
-```
+```lisp
      (defstruct-g (our-data :writers nil
                             ..
                             ..)

--- a/docs/004 - user-defined-structs.md
+++ b/docs/004 - user-defined-structs.md
@@ -1,10 +1,10 @@
 # User defined structs
 
-One of the really tricky parts of working with gpu data is laying it out in memory (and a lot of realted details that make my brain melt). Cepl simplifies this by providing a kind of struct that can be used both on the gpu and cpu.
+Laying out GPU data in memory is one of the really tricky parts of working with GPU data. CEPL simplifies this by providing a special struct that can be used both on the GPU and CPU.
 
 ### Defining
 
-You create these using defstruct-g so lets look at an example right now:
+You create these using `defstruct-g`, so lets look at an example right now:
 
 ```
      (defstruct-g our-data
@@ -12,11 +12,9 @@ You create these using defstruct-g so lets look at an example right now:
        (val :int :accessor val))
 ```
 
-This should seem familiar if you have used common lisp's structs.
+This should seem familiar if you have used Common Lisp's structs.  You provide a name, options (if you need them), and the definitions for the slots. The slots are mostly what we are interested in, so let's look at them.  
 
-You provide a name, options (if you need them) and the definitions for the slots. The slots are mostly what we are interested in, so let's look at them
-
-The format for a slot is
+The format for a slot is:
 
 ```
      (slot-name slot-type)
@@ -28,35 +26,33 @@ The format for a slot is
 
 ### Gimme one!
 
-The first example above makes a slot of the given type (which must be a cepl compatible type). Like regular lisp structs, the way you make an instance of this our `our-data` type is using the `make-our-data` function passing in values using the keyword arguments. So for example:
+The first example above makes a slot of the given type (which must be a CEPL-compatible type). As with regular Lisp structs, to make an instance of `our-data` type use the `make-our-data` function, passing in values with the keyword arguments. For example:
 
 ```
      (defvar x (make-our-data :position (v! 1 2 3) :val 5))
 ```
 
-Will return a fully populated struct **in c memory**.
+will return a fully populated struct **in c memory**.
 
-For those who havent seen it yet, the `v!` is used to make vectors. So here we are making a vector3
+For those who havent seen it yet, the `v!` syntax is used to make vectors. Here we are making a vector3.
 
-Notice that we are passing lisp data into this make function and cepl is transparently translating it to *c data*. More on this later.
+Notice that we are passing Lisp data into the `make` function and CEPL is transparently translating it to *c data*. More on this later.
 
-Remember that, like in C, not providing values for the slots leaves the field undefined. The value in the slot will be garbage and trying to retrieve it may crash cepl.
+Remember that, like in C, not providing values for the slots leaves the field undefined. The value in the slot will be garbage, and trying to retrieve it may crash CEPL.
 
 ### Accessors
 
-Notice that, in our `our-data` example, the slot named `position` doesnt have an accesor but the `val` slot does. What is going on here?
+In our `our-data` example, the slot named `position` doesn't have an accesor but the `val` slot does. What is going on here?
 
-Well both slots will get lisp-struct-style accessor functions, so you can use `(our-data-position x)` and `(our-data-val x)` to get the values in the slots.
+Well, both slots will get lisp-struct-style accessor functions, so you can use `(our-data-position x)` and `(our-data-val x)` to get the slot values.
 
-However because of the `:accessor` in `val`s slot definition you can also use the method `(val x)` to get the value of that slot, cool huh?
+However, because of the `:accessor` in `val`s slot definition, you can also use the method `(val x)` to get the value of that slot. Cool, huh?
 
 #### Performance niggle
 
-Because the result of using `:accessor` is a method there will be a performance difference between `#'our-data-val` and `#'val` when called on the cpu.
+Because the result of using `:accessor` is a method there will be a performance difference between `#'our-data-val` and `#'val` when called on the cpu.  This may not be a problem for your project, but do it keep it in mind.
 
-This may not be a problem for your project but do it keep it in mind.
-
-Also note that I said `on the cpu`. As we are going to see, our shaders are statically typed so there is *zero* performace penatly for using `#'val` on the gpu (so do it!).
+Also note that I said "on the cpu". As we shall see, our shaders are statically typed so there is *zero* performace penatly for using `#'val` on the gpu (so do it!).
 
 ### Options
 
@@ -70,34 +66,37 @@ Let's look at another example struct:
        ...)
 ```
 
-we see that this time the name is inside a list along with one or more options. This is a lot like how we can give options to regular lisp structs.
-
-These options are rather technical, and are not likely to be of interest to most people.
-
-Ok with that out of the way let's have a look at them.
+This time the name is inside a list along with one or more options. This much like providing options to regular Lisp structs. These options are rather technical, and are not likely to be of interest to most people.  OK with that out of the way, let's have a look at these options:
 
 **:constructor**
-Setting this to nil means that you will get *no* `make-` function
-Setting this to any other symbol will name the constructor using that symbol
-The default will is that the constructor will be called `make-<struct-name>`
+
+ - nil means that you will get *no* `make-` function
+ - any other symbol will name the constructor using that symbol
+ - by default the constructor will be called `make-<struct-name>`
 
 **:readers**
-Setting this to nil means that you will get *no* functions to get the slots data
+
+ - nil means that you will get *no* functions to get the slots data
 
 **:writers**
-Setting this to nil means that you will get *no* setf functions to set the slots data
+
+ - nil means that you will get *no* setf functions to set the slots data
 
 **:accesors**
-Setting this to nil means that you will get *neither* of the above.
+
+ - nil means that you will get *neither* of the above.
 
 **:pull-push**
-Setting this to nil means that you will get *no* `push-g` or `pull-g` methods defined for your type
+
+ - nil means that you will get *no* `push-g` or `pull-g` methods defined for your type
 
 **:attribs**
-Setting this to nil means that `defstruct-g` will not be able to make `gpu streams` from arrays of this type. This may not mean much until after the `gpu streams` chapter.
+ 
+ - nil means that `defstruct-g` will not be able to make `gpu streams` from arrays of this type. This may not mean much until after the `gpu streams` chapter.
 
 **:populate**
-Setting this to nil means that you will not get a `populate` function for this type.
+
+- nil means that you will not get a `populate` function for this type.
 
 
-Some of the above options are redundent in combination with others. For example the `push-g` method uses `#'populate` behind the scenes so with `populate` disabled you can have `#'push-g` for this type. Cepl needs to do a better job at communicating these conflicts to the user.
+Some of the above options are redundent in combination with others. For example, the `push-g` method uses `#'populate` behind the scenes, so with `populate` disabled `#'push-g` is created this type. CEPL needs to do a better job at communicating these conflicts to the user.

--- a/docs/005 - c-arrays.md
+++ b/docs/005 - c-arrays.md
@@ -1,16 +1,12 @@
 # C Arrays
 
-Let me take a second before getting into our scheduled programming to praise the cffi:
-
-Common Lisp's cffi is amazing, to be able to get some much done as a newbie really solidified my love for CL and cffi (and libraries using it) have been the corner stone of this entire project. To all the developers involved, You Rock.
+Let me take a second before getting into our scheduled programming to praise the cffi.  Common Lisp's cffi is amazing! To be able to get so much done as a newbie really solidified my love for CL.  cffi and libraries using it have been the cornerstone of this entire project. To all the developers involved, You Rock.
 
 ### Right, back to the snooker:
 
-So when dealing with graphics we are very often dealing with large arrays of information, information like the vectices of our meshes or positions of lights. Cffi allows us to allocate arrays of different types, but in cepl we also want to attach extra metadata that will be used behind the scenes.
+When dealing with graphics we are very often working with large arrays of information, information like the vertices of our meshes or positions of lights. cffi allows us to allocate arrays of different types, but in CEPL we also want to attach extra metadata that will be used behind the scenes.  To this end CEPL has its own c-array type that uses cffi behind the scenes.
 
-To this end cepl has its own c-array type that uses cffi behind the scenes.
-
-That was all a bit technical so lets get into how to use them.
+That was all a bit technical so lets get into how to use CEPL arrays.
 
 ```
 	 ;; 0.
@@ -33,24 +29,21 @@ That was all a bit technical so lets get into how to use them.
 	 (make-c-array #2A((1 2) (3 4)))
 ```
 
-We will go through these 1 by 1 and talk about what is going on:
+We will go through these one by one and talk about what is going on:
 
 *0:*
 In example `0` we make a c-array of 100 floats with *no initial-contents*.
 
-As you probably guessed, that first argument is where you can provide data to be used as the initial contents. By not providing it we are leaving those values un-initialized, so the normal rules apply (it may be full of garbage)
+As you probably guessed, that first `nil` argument is where you can provide data to be used as the initial contents. By not providing it we, are leaving those values uninitialized, so the normal rules apply (it may be full of garbage)
 
 *1:*
 This is simply to show that we can use our structs from the previous chapter in c-arrays.
 
 *2:*
-This little example shows that when we provide the `initial-contents` we can leave out the dimensions. The dimensions will be made the same dimensions as that of the data provided.
+This little example shows that when we provide the `initial-contents`, we can leave out the dimensions. The dimensions will be made the same as those of the data provided.
 
 *3:*
-Number 3 shows that you can even provide lisp data when the `element-type` is a cepl struct. In this case it will take each element
-of the list in order to fill in the slots of the struct.
-
-Here is the definition of that struct again:
+Number 3 shows that you can even provide Lisp data when the `element-type` is a CEPL struct. In this case, CEPL will take each element of the list in order to fill in the slots of the struct.  Here is the definition of that struct again:
 
 ```
 	 (defstruct-g our-data ()
@@ -58,12 +51,10 @@ Here is the definition of that struct again:
 	   (val :int :accessor val))
 ```
 
-So in this case we end up with a c-array with two elements of type `our-data`, the first struct has the `position` `(v! 1 2 3)` and the `val` `10`; the second struct has the `position` `(v! 4 5 6)` and the `val` 20.
+So in this case we end up with a c-array with two elements of type `our-data`. The first struct has the `position` `(v! 1 2 3)` and the `val` `10`; the second struct has the `position` `(v! 4 5 6)` and the `val` 20.
 
 *4:*
-Hey now this is odd, we only provide the lisp data, how does cepl know what to do?
-
-What happens is that `#'make-c-array` scans each element of the lisp data and tries to find the *smallest cepl compatible type* that will hold all the values. In this case because of the number `3.0` in there the array has to have `element-type` `:float`.
+Hey now, this is odd, we only provide the lisp data. How does CEPL know what to do?  Here `#'make-c-array` scans each element of the Lisp data and tries to find the *smallest cepl compatible type* that will hold all the values. In this case, because of the number `3.0`, the array has to have `element-type` `:float`.
 
 Now this feature is very handy (especially in the repl) but there are some caveats.
 
@@ -71,13 +62,13 @@ Now this feature is very handy (especially in the repl) but there are some cavea
   `:uint8` `:int8` `:int` `:float` & `:double`
 
 - Scanning for types is not fast:
-  This is a great feature to use at the repl, because odds are cepl can work out the type fast enough that you won't notice a delay. **However** this is not a good type to use in performance critical code, so if you need the speed, always specify your `element-type`
+  This is a great feature to use at the REPL, because odds are CEPL can work out the type fast enough that you won't notice a delay. **However** this is not good in performance-critical code, so if you need the speed, always specify your `element-type`
 
 *5:*
 This shows two things:
 
-First: that c-arrays can take arrays (of multiple dimensions also)
-Second: The `element-type` that cepl will give this array is `:uint8`. The reason is that all the elements are between 0 & 255.
+ - c-arrays can take arrays (of multiple dimensions also)
+ - The `element-type` that cepl will give this array is `:uint8`. The reason is that all the elements are between 0 & 255.
 
 If we were to write:
 

--- a/docs/005 - c-arrays.md
+++ b/docs/005 - c-arrays.md
@@ -1,12 +1,12 @@
 # C Arrays
 
-Let me take a second before getting into our scheduled programming to praise the cffi.  Common Lisp's cffi is amazing! To be able to get so much done as a newbie really solidified my love for CL.  cffi and libraries using it have been the cornerstone of this entire project. To all the developers involved, You Rock.
+Let me take a second before getting into our scheduled programming to praise the CFFI.  Common Lisp's CFFI is amazing! To be able to get so much done as a newbie really solidified my love for CL.  CFFI and libraries using it have been the cornerstone of this entire project. To all the developers involved, You Rock.
 
 ### Right, back to the snooker:
 
-When dealing with graphics we are very often working with large arrays of information, information like the vertices of our meshes or positions of lights. cffi allows us to allocate arrays of different types, but in CEPL we also want to attach extra metadata that will be used behind the scenes.  To this end CEPL has its own c-array type that uses cffi behind the scenes.
+When dealing with graphics we are very often working with large arrays of information, information like the vertices of our meshes or positions of lights. CFFI allows us to allocate arrays of different types, but in CEPL we also want to attach extra metadata that will be used behind the scenes.  To this end CEPL has its own c-array type that uses CFFI behind the scenes.
 
-In this document, the terms "C arrays" and "c-array" refer to the special cffi arrays that are managed by CEPL.
+In this document, the terms "C arrays" and "c-array" refer to the special CFFI arrays that are managed by CEPL.
 
 That was all a bit technical so lets get into how to use CEPL arrays.
 ```lisp

--- a/docs/006 - gpu-arrays.md
+++ b/docs/006 - gpu-arrays.md
@@ -1,192 +1,175 @@
 # GPU Arrays
 
-Finally, we are making something on the gpu, surely this is a monster of a task...
-
-well no.
-
-Actually the basics work exactly the same and in c-array
+Finally, we are making something on the GPU... Surely this is a monster of a task... Well, no.  Actually the basics work exactly the same as in `c-array`.
 
 Let's do some comparisons of the usage of `#'make-c-array` and `#'make-gpu-array`
+```lisp
+;; 0.
+(make-c-array nil :dimensions 100 :element-type :float)
+(make-gpu-array nil :dimensions 100 :element-type :float)
 
-```
-	 ;; 0.
-	 (make-c-array nil :dimensions 100 :element-type :float)
-	 (make-gpu-array nil :dimensions 100 :element-type :float)
+;; 1.
+(make-c-array nil :dimensions 100 :element-type 'our-data)
+(make-gpu-array nil :dimensions 100 :element-type 'our-data)
 
-	 ;; 1.
-	 (make-c-array nil :dimensions 100 :element-type 'our-data)
-	 (make-gpu-array nil :dimensions 100 :element-type 'our-data)
+;; 2.
+(make-c-array '(1.0 2.0 3.0 4.0) :element-type :float)
+(make-gpu-array '(1.0 2.0 3.0 4.0) :element-type :float)
 
-	 ;; 2.
-	 (make-c-array '(1.0 2.0 3.0 4.0) :element-type :float)
-	 (make-gpu-array '(1.0 2.0 3.0 4.0) :element-type :float)
+;; 3.
+(make-c-array `((,(v! 1 2 3) 10) (,(v! 4 5 6) 20))
+              :element-type 'our-data)
+(make-gpu-array `((,(v! 1 2 3) 10) (,(v! 4 5 6) 20))
+                 :element-type 'our-data)
 
-	 ;; 3.
-	 (make-c-array `((,(v! 1 2 3) 10) (,(v! 4 5 6) 20))
-                   :element-type 'our-data)
-	 (make-gpu-array `((,(v! 1 2 3) 10) (,(v! 4 5 6) 20))
-                   :element-type 'our-data)
+;; 4.
+(make-c-array '(1 2 3.0 4))
+(make-gpu-array '(1 2 3.0 4))
 
-	 ;; 4.
-     (make-c-array '(1 2 3.0 4))
-     (make-gpu-array '(1 2 3.0 4))
-
-	 ;; 5.
-	 (make-c-array #2A((1 2) (3 4)))
-	 (make-gpu-array #2A((1 2) (3 4)))
+;; 5.
+(make-c-array #2A((1 2) (3 4)))
+(make-gpu-array #2A((1 2) (3 4)))
 ```
 
 Pretty cool!
 
-Just like with `c-array` there are two extra arguments, one of which is alignment which works the same way as in `c-array` (which means right now it doesnt :p), and then there is `access-style`
+Just like with `c-array` there are two extra arguments:
 
-But wait, `#'make-gpu-array` also has another trick. It can take a `c-array` as the first argument and upload that data to the gpu-array. This is really fast as the is no type conversion to be done before upload. Also it's cool as you dont need to provide any extra information as `c-array`s contain all the metadata `make-gpu-array` needs to work.
+- `alignment`, which works the same way as in `c-array` (which means right now it doesnt :p);
+- `access-style` is discussed in the next section.
 
+But wait, `#'make-gpu-array` also has another trick. It can take a `c-array` as the first argument, and upload that data to the gpu-array. This is really fast as the is no type conversion to be done before the upload. Also it's cool as you dont need to provide any extra information -- `c-array`s contain all the metadata that `make-gpu-array` needs.
 
 ### Access-Style
 
-This argument is a optimization hint that is given to opengl to say how you expect to be accessing this data.
+This argument is a optimization hint that is given to OpenGL to specify how you expect to access data. This bit it pretty technical; if you dont know what you need, just let CEPL use the default.
 
-This bit it pretty technical so if you dont know what you need, just let cepl use the default.
+The reason to use `access-style` hint is that it enables the OpenGL implementation to make more intelligent decisions and possibly  significantly improve GPU performance. It does not, however, constrain the actual usage of the array. 
 
-This enables the OpenGL implementation to make more intelligent decisions that may significantly impact gpu-array performance. It does not, however, constrain the actual usage of the array. `Access-Style` can be broken down into two parts: first, the frequency of access (modification and usage), and second, the nature of that access.
+`Access-Style` is a compound of two words joined with an underscore, :
+
+- prefix, the frequency of access (modification and usage)
+- suffix the nature of that access.
 
 The frequency of access may be one of these:
 
-> :STREAM - The data store contents will be modified once and used at most a few times.
-> :STATIC - The data store contents will be modified once and used many times.
-> :DYNAMIC - The data store contents will be modified repeatedly and used many times.
+| prefix | Expected datastore access pattern |
+|:--------|:----------------------------------|
+| STREAM  | Modified once and read occasionally |
+| STATIC  | Modified once and read many times |
+| DYNAMIC | Modified repeatedly and read many times |
 
 The nature of access may be one of these:
 
-> :DRAW - The data store contents are modified by the application, and used as the source for GL drawing and image specification commands.
-> :READ - The data store contents are modified by reading data from the GL, and used to return that data when queried by the application.
-> :COPY - The data store contents are modified by reading data from the GL, and used as the source for GL drawing and image specification commands.
+| suffix | Expected datastore access nature |
+|:--------|:----------------------------------|
+| DRAW | Modified by the application, used as the source for GL drawing and image specification commands |
+| READ | Modified by reading data from the GL, used to return that data when queried by the application |
+| COPY | Modified by reading data from the GL, used as the source for GL drawing and image specification commands |
 
-So combined we get these choices:
+So, when combined, we get these nine possible keywords:
 
-> :STREAM_DRAW :STREAM_READ :STREAM_COPY
-> :STATIC_DRAW :STATIC_READ :STATIC_COPY
-> :DYNAMIC_DRAW :DYNAMIC_READ :DYNAMIC_COPY.
+|   |   |   |
+|---|---|---|
+| :STREAM_DRAW | :STREAM_READ | :STREAM_COPY |
+| :STATIC_DRAW | :STATIC_READ | :STATIC_COPY |
+| :DYNAMIC_DRAW | :DYNAMIC_READ | :DYNAMIC_COPY |
 
 ### So we have #'aref-g, right?
 
-Well no actually. Whilst we could implement it in 2 minutes it would be a bad idea. The reason for this is that communicating with the gpu is costly, especially if you are in the middle of rendering something. By giving a complimentary usage to `aref-c` it may feel like we are saying that the access costs are similar, and that would be **very** misleading.
+Well no actually. While we could implement it in 2 minutes it, would be a *bad idea*. The reason for this is that communicating with the gpu is costly, especially in the middle of rendering. Providing `aref-g` might imply that the access costs are similar to `aref` or `aref-c`, which would be **very misleading**.
 
-Instead we have ways to push large chunks of data to the array (which is how things are usually done) and for the times you absolutely need random access to a gpu-array we have the `with-gpu-array-as-c-array` macro.
+Instead, we have ways to explicitly move large chunks of data to and from the array (which is how things are usually done). For the times you absolutely need random access to a `gpu-array`, we have the `with-gpu-array-as-c-array` macro. It maps a `gpu-array` to a `c-array`, which allows you to perform any of the `c-array` operations on it.
 
-It takes a gpu-array and maps it as a c-array which allows you to run any of the c-array commands on it.
-
-A simple example would be if we wanted to set the 3rd element in a gpu array to 5.0 we could do the following:
-
-```
-	(with-gpu-array-as-c-array (mygpuarray)
-	  (setf (aref-c mygpuarray 2) 5.0))
+A simple example is setting the 3rd element in a `gpu-array` to 5.0:
+```lisp
+(with-gpu-array-as-c-array (mygpuarray)
+  (setf (aref-c mygpuarray 2) 5.0))
 ```
 
-Very cool!
+Very cool! OpenGL does some magic to map the memory containing the `gpu-array` to the local address space. CEPL gets a pointer to it and thus is able to present a `c-array` to you.
 
-When you do this OpenGL does some magic to map the memory containing the gpu-array to the local address space. This let's cepl get a pointer to it and thus be able to present a c-array to you.
+Of course, don't try to be sneaky and use this c-array outside the scope of `with-gpu-array-as-c-array`.
 
-Of course don't try and be sneaky and copy this c-array somewhere, at the end of the `with-gpu-array-as-c-array`'s scope the gpu memory is
-
-The valid values for access are `:read-only` `:write-only` & `:read-write`
+The valid values for access are `:read-only`, `:write-only` and `:read-write`
 
 *Performance Note:*
 
-I've taken this from the OpenGL wiki and modified it to use cepl's terminology:
+I've taken this from the OpenGL wiki and modified it to use CEPL's terminology:
 
-> Mappings to the data stores of `gpu-arrays` may have nonstandard performance characteristics. For example, such mappings may be marked as uncacheable regions of memory, and in such cases reading from them may be very slow. To ensure optimal performance, the client should use the mapping in a fashion consistent with the values of `:access-style` for the `gpu-array` and of access. Using a mapping in a fashion inconsistent with these values is liable to be multiple orders of magnitude slower than using normal memory.
+> Mappings to the data stores of `gpu-arrays` may have nonstandard performance characteristics. For example, such mappings may be marked as uncacheable regions of memory, and in such cases reading from them may be very slow. To ensure optimal performance, the client should use the mapping in a fashion consistent with the values of `:access-style` for the `gpu-array` and of access. Using a mapping in a fashion inconsistent with these values is liable to be **multiple orders of magnitude slower** than using normal memory.
 
-So again, don't assume you will get good performance, this is not how you should be interacting with your gpu-arrays normally.
+So again, don't assume you will get good performance; this is not how you should be interacting with your `gpu-array`s normally.
 
 ### Structs and gpu-arrays
 
-One nice thing that cepl does for you if you use our structs is to *interleave* your struct data.
+One nice benefit of using CEPL structs is the *interleaving* of your struct data.
 
-Imagine you have a model of a goat with has 3000 vertices, and each vertex of the goat has a position, uv coordinates and a normal vector. One way to store it would be:
+Imagine you have a model of a goat with 3000 vertices. Each vertex has a position, uv coordinates, and a normal vector. One way to store it would be:
 
 `[ the 1000 positions | the 1000 uv coordinates | the 1000 normal vectors ]`
 
-And this would work, but it means that when the gpu want to render the first vertex, it has to jump to 3 places in memory to get the data. That's gonna hurt performance.
+This would work, but it means that when the GPU renders the first vertex, it has to jump to 3 places in memory to get the data. That's gonna hurt performance.
 
-Instead if we make an struct like this:
-
+Instead, if we make an struct like this:
+```lisp
+ (defstruct-g goat-vertex
+   (position :vec3)
+   (uv :vec2)
+   (normal :vec3))
 ```
-	 (defstruct-g goat-vertex
-	   (position :vec3)
-	   (uv :vec2)
-	   (normal :vec3))
-```
-
 and make the array like this:
-
-```
+```lisp
      (make-gpu-array nil :dimensions 1000 :element-type 'goat-vertex)
 ```
-
-The the data is laid out like this
-
+The the data is automatically laid out like this
 ```
      [first pos | first uv | first normal | second pos | second uv | second normal | .. etc .. ]
 ```
 
-This really helps the gpu, and cepl makes it easy, do it :)
+This really helps the gpu, and CEPL makes it easy; do it :)
 
 
 ### subseq-g
 
-`#'subseq-g` is a just like `#'subseq-c` except that it takes a `gpu-array` and give you a new one which shares a subset of the memory of the original. Like with `#'subseq-c` the data is shared so you have to be super careful not to mangle or free the data.
+`#'subseq-g` is a just like `#'subseq-c`: it takes a `gpu-array` and gives you a new `gpu-array` which shares a subset of the GPU memory of the original. Like with `#'subseq-c` **the data is shared** so you have to be super careful not to mangle or free the data.
 
 
 ### What is this 'Backed-By' stuff?
 
 If you are playing along at home you may have tried something like this:
-
-```
+```lisp
 	 CEPL> (make-gpu-array '(1 2 3))
 ```
-
 and got back an object like this
-
 ```
 	 #<GPU-ARRAY :element-type :UBYTE :dimensions (3) :backed-by :BUFFER>
 ```
+..which seems fine, except for that `:backed-by` thing. What is going on there?
 
-..which seems fine, except for that `:backed-by` thing, what is going on there?
+Well, what you are seeing is information about what kind of GPU memory your data is being stored in.  GPUs are made for games; the whole game industry drives the GPU industry, and GPU engineers work damn hard to be able to support the kinds of techniques game developers are using. However much you optimize your code, you just can't beat custom hardware, so when there are obvious patterns of how data on the gpu is used, the hardware is customized to support it.
 
-Well what you are seeing is information about what kind of gpu memory your data is being stored in.
+> Note: This is simplified, of course. The game/gpu industries are in a mad cycle which feeds one another. This kind of resonant systems (think of an echo chamber) can end up with some odd results, such as hardware being optimized for AAA games like `Crysis`. It's all a bit weird and not a topic I'm going to get into.
 
-GPUs are made for games, the whole game industry drives the GPU industry and so GPU engineers work damn hard to be able to support the kinds of techniques game developers are trying to achieve. However much you optimize your code, you can just never beat having custom hardware so when you see big patterns in how data on the gpu is used, you will want to customize the hardware to support it.
+So two big patterns in GPU data usage are how we read vertex data and how we read texture data. Having two different pools with different access styles allows GPU designers to optimize the hell out of it. Ι don't want to get too deep so let's get back to `:backed-by`.
 
-> Note: This is simplified of course, the game/gpu industries are a mad cycle which feeds eachother, this kind of system (or echo chamber) can end up with some odd results, like hardware being optimized for AAA games like crysis. It's all a bit weird an not a topic I'm gonna get into.
-
-So two big patterns we notice in data usage are how we read vertex data and how we read texture data. By having two different pools with different access styles they can optimize the hell out of it. Ι don't want to get too deep so let's get back to `:backed-by`.
-
-OpenGL provides textures (which we will get into later) and 'Buffer Objects' which we will refer to as `buffers` from now on.
-
+OpenGL provides textures (which we will get into later) and 'Buffer Objects' which we will refer to as `buffers` from now on. 
 `buffers` allow you to allocate a block of `buffer memory` and then upload data there. There is no real limit of what you can stick up there, but there are *effective limits* as there only certain things you can *do* with the data once it's there.
 
-So whilst we could just expose these buffers (and we do, see chapter [006]("./006 - Buffers.md")) in cepl we choose to also expose objects that map more directly to what you do with this data.
+So while we could just expose these buffers (and we do, see chapter [007]("./007 - Buffers.md")) in CEPL, we choose to also expose objects that map more directly to what you do with this data.  `gpu-arrays` are one case of this. All 3d models have their vertex data stored sequentially in a buffer object; this data has a length and a definite layout of the 'elements'. This is pretty much the definition for a kind of array.
 
-`Gpu-arrays` are one case of this. All your 3d models you render will have their vertex data stored sequentially in a buffer object, this data has a length and has an definite layour of the 'elements'..this is pretty much the definition for a kind of array.
-
-As we will soon see, the `gpu-array` abstraction is also useful with textures, so we need a way to show you whether this gpu-array is `backed-by` a `buffer memory` or `texture memory`.
-
+As we will soon see, the `gpu-array` abstraction is also useful with textures, so we need a way to show you whether this `gpu-array` is `backed-by` a `buffer memory` or `texture memory`.
 
 ### Multiple gpu-arrays in the same buffer
 
-There are valids reason to want certain gpu-arrays to live in the same `buffer object`.
-
-To do this use the `make-gpu-arrays` function
-
-This is the signature: `(c-arrays &key (access-style :static-draw))`
-
+There are valid reasons to place certain `gpu-array`s in the same `buffer object`. To do this use the `make-gpu-arrays` function:
+```lisp
+(make-gpu-arrays (c-arrays &key (access-style :static-draw)))`
+```
 This function creates a list of gpu-arrays residing in a single buffer in opengl. It create one gpu-array for each c-array in the list passed in.
 
-The `:access-style` is shared by all gpu-arrays in the `buffer object` but is otherwise the same as defined earlier.
-
+The `:access-style` is shared by all gpu-arrays in the `buffer object`, but otherwise is the same as defined earlier.
 
 ### Freeing gpu-arrays
 
-You can use either `#'free` or `#'free-gpu-array` to free gpu arrays.
+You can use either `#'free` or `#'free-gpu-array` to free GPU arrays.

--- a/docs/007 - Buffers.md
+++ b/docs/007 - Buffers.md
@@ -1,112 +1,83 @@
 # Buffers
 
-Most people can safely skip this chapter. It is only relevent if you really want to understand how cepl allocates `buffer objects`.
+Most people can safely skip this chapter. It is only relevant if you really want to understand how CEPL allocates `buffer objects`.
 
-This chapter will be more of an api-reference than a guide, if you want to use this then you already know what you are doing
+This chapter will be more of an api-reference than a guide; if you want to use this you already know what you are doing.
 
-`buffers.lisp` is where we have all the code for making `OpenGL`'s `buffer object`s and for uploading data to those buffers.
+`buffers.lisp` contains all the code for making `OpenGL`'s `buffer object`s and uploading data to those buffers.
 
 
 ### Data Layout
 
-A buffer object is just a chunk of the GPU's `buffer memory` but it's not like you are going to just be storing random data up there, so naturally you are going to have some kind of layout.
+A buffer object is just a chunk of the GPU's `buffer memory`, with a particular memory layout.
 
 Buffer layouts are defined as lists of the format:
-
-```
-     (data-type data-index-length offset-in-bytes-into-buffer)
+```lisp
+(data-type data-index-length offset-in-bytes-into-buffer)
 ```
 
 So a layout for a buffer containing 3 `:floats` and 140 instances of our `our-data` struct type looks like this:
-
+```lisp
+`((:float 3 0) ('vert-data 140 12))
 ```
-     `((:float 3 0) ('vert-data 140 12))
-```
 
-With this knowledge we can now start doing things with buffers
+With this knowledge we can now start working with buffers:
 
 ### Making Buffers
-
-`#'make-gpu-buffer`:
-
+```lisp
+(make-gpu-buffer (&key initial-contents
+                   (buffer-target :array-buffer)
+                   (usage :static-draw)
+                   (managed nil)))
 ```
-     Signature: (&key initial-contents
-                      (buffer-target :array-buffer)
-                      (usage :static-draw)
-                      (managed nil))
-```
-
-Creates a new opengl `buffer object`.
+Creates a new OpenGL `buffer object`.
 
 You can optionally provide a `c-array` as the `:initial-contents` to have the buffer populated with the contents of the array.
 
 Usage in this case is the same as in `gpu-arrays`
 
-`Managed` is a flag used by cepl to indicate that a gpu-array owns the buffer. When this is true, and you free the `gpu-array` that uses this buffer, then the buffer is freed at the same time.
+`Managed` is a flag used by CEPL to indicate that a gpu-array owns the buffer. When true, freeing the `gpu-array` that uses this buffer, frees the buffer the same time.
 
 ### Reserve Space
-
-`#'buffer-reserve-block`
-
+```lisp
+(buffer-reserve-block (buffer type dimensions buffer-target usage))
 ```
-     Signature: (buffer type dimensions buffer-target usage)
-```
-
-This function creates an empty block of data in the opengl buffer large enough to contain `(apply #'* dimensions)` elements of the specified type
+This function creates an empty block of data in the OpenGL buffer, large enough to contain `(apply #'* dimensions)` elements of the specified type.
 
 It will remove ALL data currently in the buffer
 
-
 ### Uploading Data
-
-`#'buffer-data`
-
+```lisp
+(buffer-data (buffer c-array buffer-target usage
+               &key (offset 0) (size (c-array-byte-size c-array))))
 ```
-     Signature: (buffer c-array buffer-target usage
-                 &key (offset 0) (size (c-array-byte-size c-array))
-```
-
-This function populates an opengl buffer with the contents of the array. You also pass in the buffer target and the draw type this buffer is to be used for.
+This function populates an OpenGL buffer with the contents of the array. It requires the buffer target and the usage indicating what this buffer is to be used for.
 
 The function returns a buffer object with its format slot populated with the details of the data stored within the buffer.
-
-
-`#'multi-buffer-data`
-
+```lisp
+(multi-buffer-data (buffer c-arrays buffer-target usage))
 ```
-     Signature: (buffer c-arrays buffer-target usage)
+This beast will take a list of c-arrays and auto-magically push them into a buffer, taking care of both interleaving and sequencial data, and handling all the offsets.
+```lisp
+(buffer-sub-data (buffer c-array byte-offset buffer-target
+                   &key (safe t)))
 ```
+This function replaces a subsection of the data in the specified buffer with the data in the `c-array`.
 
-This beast will take a list of c-arrays and auto-magically push them into a buffer taking care of both interleaving and sequencial data and handling all the offsets.
+The `byte-offset` parameter specifies where you wish to start overwriting data from.
 
-
-`#'buffer-sub-data`
-```
-     Signature: (buffer c-array byte-offset buffer-target
-                 &key (safe t))
-```
-
-This function replaces a subsection of the data in the specified buffer with the data in the c-array.
-
-The byte offset specifies where you wish to start overwriting data from.
-
-When the :safe option is t, the function checks to see if the data you are about to write into the buffer will cross the boundaries between data already in the buffer and will emit an error if you are.
+When the `:safe` option is `t`, the function checks to see if the data you are about to write into the buffer will cross the boundaries between data already in the buffer, and will emit an error if necessary.
 
 ### Bind a buffer
-
-`with-buffer macro`
-
+Macro:
+```lisp
+(with-buffer ((var-name buffer &optional (buffer-target :array-buffer)) &body body))
 ```
-     Signature: ((var-name buffer &optional (buffer-target :array-buffer)) &body body
-```
-
 Example
-
+```lisp
+(with-buffer (x some-buffer)
+  (buffer-sub-data x ...other args...))
 ```
-	 (with-buffer (x some-buffer)
-	   (buffer-sub-data x ...other args...))
-```
-
 ### Free buffer
 
 Buffers can be freed with `#'free` or `#'free-buffer`

--- a/docs/008 - textures - making and freeing them.md
+++ b/docs/008 - textures - making and freeing them.md
@@ -1,21 +1,21 @@
 
 # Textures
 
-Ah textures! The area of opengl with probably the most misleading names in all of graphics.
+Ah, textures! The area of OpenGL with probably the most misleading names in all of graphics.
 
 #### Texture
 
-Lets start with textures themselves. I cant speak for everyone but when I started this Ι thought a texture was a kind of image that you wrapped onto the 3d model in your game/application/whatever. It turns out that I was very wrong.
+Lets start with textures themselves. I can't speak for everyone, but when I started this, Ι thought a texture was a kind of image that you wrapped onto the 3d model in your game/application/whatever. It turns out that I was very wrong.
 
-The open gl spec says:
+The OpenGL spec says:
 
 > A texture is an OpenGL Object that contains one or more images that all have the same image format.
 
-So a texture is a datastructure that contains a number of 'images'
+So a texture is a datastructure that contains a number of 'images'.
 
 #### Image
 
-But image is well named right? NO! An 'image' in opengl can be 1, 2 or 3 dimensional. It can contain bytes, floats, doubles, vectors..these are starting to sounds just like arrays again! Actually thats really what they are, arrays with some extra features of course, but arrays none the less. In fact the GL wiki makes this very clear:
+But *image* is well named, right? NO! An *image* in opengl can be 1-, 2-, or 3-dimensional. It can contain bytes, floats, doubles, vectors... these are starting to sounds just like arrays again! Actually that is really what they are: arrays, with some extra features of course, but arrays none the less. In fact the GL wiki makes this very clear:
 
 > an image is defined as a single array of pixels of a certain dimensionality (1D, 2D, or 3D), with a particular size, and a specific format.
 
@@ -23,27 +23,24 @@ Reading the data out of a gpu-array (image) in a shader is called `sampling`
 
 #### Return of Gpu-Array
 
-Given that we already have an abstraction for arrays on the gpu it made sense to use it here.
+Given that we already have an abstraction for arrays on the GPU, it is sensible to use it here.
 
-If you have read chapter `005` you will have seen that gpu-arrays tell you what kind of memory they are `backed by`. So, for example, the following code:
-
-```
+If you have read chapter [`006`](006 - gpu-arrays.md), you have seen that `gpu-array`s tell you what kind of memory they are `backed by`. So, for example, the following code:
+```lisp
      (make-gpu-array '(1 2 3))
 ```
-
 gives us this:
-
-```
+```lisp
      #<GPU-ARRAY :element-type :UINT8 :dimensions (3) :backed-by :BUFFER>
 ```
 
-Which is a gpu-array *backed by* an opengl buffer, which meant the data for the array was stored in an opengl buffer.
+Which is a `gpu-array` *backed by* an OpenGL buffer, which means that the data for the array is stored in an OpenGL buffer.
 
-When we access a gpu-array from inside a texture we will see it is *backed-by* `:texture`..But we are getting ahead of ourselves, let's recap.
+When we access a `gpu-array` from a texture we will see it is *backed-by* `:texture`... But we are getting ahead of ourselves, let's recap.
 
 #### Where were we?
 
-Ok so in cepl terminology a texture is a datastructure that contains 1 or more gpu-arrays. Opengl textures can a have a bewildering number of options applied to them and while cepl can make the experience easier, some things are just gonna be confusing at first. Rest assured though that you can get useful stuff done without knowing all of it. If you want to survey your options check out this pages:
+OK, so in CEPL terminology, a *texture* is a datastructure that contains 1 or more gpu-arrays. OpenGL textures can a have a bewildering number of options applied to them and while CEPL can make the experience easier, some things are just going to be confusing at first. Rest assured that you can get useful stuff done without knowing all of it. If you want to survey your options check out this pages:
 
 https://www.opengl.org/wiki/Texture
 https://www.opengl.org/wiki/Texture_Storage
@@ -52,65 +49,55 @@ With that said let's begin. I'm going to start with a bunch of simple examples t
 
 #### 1D Texture
 
-It's fairly common to talk about a texture with a single 1 dimensional array as a 1D texture. To make one of these is very similar to making a c-array or gpu-array
-
-```
+It's fairly common to talk about a texture with a single 1-dimensional array as a 1D texture. Creating one of these is very similar to making a c-array or gpu-array:
+```lisp
 CEPL> (defvar x (make-texture '(1 2 3 4)))
 #<GL-TEXTURE-1D (4)>
 ```
 
-This is the simplest possible texture, notice how it uses the same technique as before if you dont provide the `:element-type`.
+This is the simplest possible texture. Notice how it infers the type if you don't provide the `:element-type`.
 
-How about we take a look at the gpu-array inside this texture?
+How about we take a look at the `gpu-array` inside this texture?
 
-Like we have `aref` for lisp arrays and `aref-c` for `c-arrays`, we have `texref` for looking inside textures. `texref` lets you index into the texture by the `mipmap-level` `layer` and `cube-face`, these are opengl terms we havent covered yet so dont worry if they are foreign. They are all optional so if our texture only has one image then you only need to do this:
-
-```
+As `aref` for lisp arrays and `aref-c` for `c-arrays`, we have `texref` for looking inside textures. `texref` lets you index into the texture by the `mipmap-level` `layer` and `cube-face`; these are OpenGL terms we haven't covered yet, so don't worry if they are foreign. They are all optional, so if our texture only has one image then you only need to do this:
+```lisp
 CEPL> (defvar a (texref x))
 #<GPU-ARRAY :element-type :R8 :dimensions (4) :backed-by :TEXTURE>
 ```
-
 Well that looks familiar!
 
 `pull-g` still works of course:
-
-```
+```lisp
 CEPL> (pull-g a)
 (1 2 3 4)
 ```
-
-As does `push-g`
-
-```
+As does `push-g`:
+```lisp
 (push-g '(5 6 7 8) a)
 #<GPU-ARRAY :element-type :R8 :dimensions (4) :backed-by :TEXTURE>
 ```
-
-As before we can make an array without initializing the contents
-
-```
+As before we can make an array without initializing the contents:
+```lisp
 CEPL> (make-texture nil :dimensions 10 :element-type :uint8)
 #<GL-TEXTURE-1D (10)>
 CEPL> (texref *)
 #<GPU-ARRAY :element-type :R8 :dimensions (10) :backed-by :TEXTURE>
 ```
-
-Eagle-eyed readers will notice that the `:element-type` we provided was `:uint8` yet the `:element-type` of the gpu-array is `:r8`. Textures have special type names for their data and Cepl is just picking the matching type. OpenGL's textures types are a topic of their own so I'll cover it a bit later. For now just know that Cepl lets you use regular types when it can work out the equivalent **or** the official OpenGL names.
+Eagle-eyed readers will notice that the `:element-type` we provided was `:uint8`, yet the `:element-type` of the gpu-array is `:r8`. Textures have special type names for their data and CEPL is just picking the matching type. OpenGL's texture types are a topic of their own so I'll cover it a bit later. For now just know that CEPL lets you use regular types when it can work out the equivalent **or** the official OpenGL names.
 
 #### More dimensions
 
-We can make 2D and 3D textures as we would expect
-```
+We can make 2D and 3D textures as we would expect:
+```lisp
 CEPL> (make-texture #2A ((1 2 3) (4 5 6)))
 #<GL-TEXTURE-2D (2x3)>
 
 CEPL> (make-texture nil :dimensions '(10 10 10) :element-type :uint8)
 #<GL-TEXTURE-3D (10x10x10)>
 ```
-
 #### Subseq-g for Texture backed gpu-arrays?
 
-Having this would mean we could `pull-g` from, and `push-g` to, a portion of the texture. This is on the roadmap but not currently implemented.
+Having this implies that we could `pull-g` from, and `push-g` to, a portion of the texture. This is on the roadmap but not currently implemented.
 
 #### MipMaps
 
@@ -136,14 +123,13 @@ There are two mipmap related `&keys` in `#'make-texture`, `:mipmap` and `:genera
 - `:mipmap` let's you pick the number of mipmap levels there will be
 - `:generate-mipmaps` is either `t` or `nil` and specifies whether GL will generate the mipmap images for you or not.
 
-```
+```lisp
 CEPL> (defvar x2d (make-texture nil :dimensions '(512 512) :element-type :uint8-vec4  :mipmap 4 :generate-mipmaps t))
 #<GL-TEXTURE-2D (512x512) mip-levels:4>
 ```
 
 To get those different gpu-arrays we can still use `texref` but we can now use the mipmap-level `&key`
-
-```
+```lisp
 CEPL> (texref x2d :mipmap-level 0)
 #<GPU-ARRAY :element-type :RGBA8 :dimensions (512 512) :backed-by :TEXTURE>
 CEPL> (texref x2d :mipmap-level 1)
@@ -152,9 +138,9 @@ CEPL> (texref x2d :mipmap-level 2)
 #<GPU-ARRAY :element-type :RGBA8 :dimensions (85 85) :backed-by :TEXTURE>
 ```
 
-Remember each level is just a gpu-array so `pull-g`ing and `push-g`ing to them work just fine.
+Remember each level is just a `gpu-array` so `pull-g`ing and `push-g`ing to them work just fine.
 
-If you want to generate mipmaps for an existing texture, simply call #'generate-mipmaps on it.
+If you want to generate mipmaps for an existing texture, simply call `#'generate-mipmaps` on it.
 
 #### Cube Textures
 
@@ -162,20 +148,18 @@ Cube textures are pretty cool, as the GL wiki puts it:
 
 > A Cubemap Texture is a texture, where each mipmap level consists of six 2D images. The images are arranged in a cube-shape, hence the name. Cubemaps can have multiple mipmap levels.
 
-So in our parlance a cubemap texture has 6 2d gpu-arrays at each mipmap level.
+So in our parlance, a cubemap texture has 6 2D `gpu-arrays` at each mipmap level.
 
 The way we sample the data from cube textures is cool, you can read all the gory details here: https://www.opengl.org/wiki/Cubemap_Texture#Samplers
 
-To make a cube-texture in Cepl we can write the following:
-
-```
+To make a cube-texture in CEPL we can write the following:
+```lisp
 CEPL> (defvar c (make-texture nil :dimensions '(10 10) :element-type :uint8-vec4 :cubes t))
 #<GL-TEXTURE-CUBE-MAP (10x10)>
 ```
 
-And to access the gpu-arrays
-
-```
+And to access the `gpu-arrays`
+```lisp
 CEPL> (texref c :cube-face 0)
 #<GPU-ARRAY :element-type :RGBA8 :dimensions (10 10) :backed-by :TEXTURE>
 CEPL> (texref c :cube-face 3)
@@ -184,7 +168,7 @@ CEPL> (texref c :cube-face 3)
 
 #### Array-Textures
 
-Textures can hold also arrays of gpu-arrays. The description from the wiki is as follows:
+Textures can hold also arrays of `gpu-arrays`. The description from the wiki is as follows:
 
 > An Array Texture is a Texture where each mipmap level contains an array of images of the same size. Array textures may have Mipmaps, but each mipmap in the texture has the same number of levels.
 
@@ -194,14 +178,11 @@ As always, the source of truth on these matters in the GL spec and https://www.o
 
 Array-Textures can be arrays of 1D, 2D, 3D or Cube texture. Cepl tries to get this right but, to be honest, it gets rather confusing. If you find a combination that should work (according to the GL spec) and doesnt, please let us know on github.
 
-To make an array texture we do this using the `:layer-count` `&key` argument
-
-```
+To make an array texture we use the `:layer-count` `&key` argument:
+```lisp
 (make-texture nil :dimensions 10 :element-type :uint8-vec4 :layer-count 8)
-ERROR
+#<TEXTURE-1D-ARRAY (10) layers:8>
 ```
-Woops, seems Cepl has a bug. You can track this here: https://github.com/cbaggers/cepl/issues/48
-
 
 #### Buffer Textures
 
@@ -215,19 +196,17 @@ There are a bunch of limitations to buffer textures (other than being 1D)
 - cannot use filtering (which we havent covered yet)
 - cannot have mipmaps
 
-Making them is super easy though
-
-```
+Making them is super easy, though:
+```lisp
 CEPL> (defvar b (make-texture nil :dimensions 10 :element-type :uint8-vec4 :buffer-storage t))
 #<GL-TEXTURE-BUFFER (10)>
 ```
-And the fun bit is, we have the perfect type for the gpu-array :)
-
-```
+And the fun bit is: we have the perfect type for the gpu-array :)
+```lisp
 CEPL> (texref b)
 #<GPU-ARRAY :element-type :UINT8-VEC4 :dimensions (10) :backed-by :BUFFER>
 ```
-Yup, a **buffer-backed** gpu-array!
+Yup, a **buffer-backed** `gpu-array`!
 
 
 #### Rectangle Textures
@@ -235,8 +214,7 @@ Yup, a **buffer-backed** gpu-array!
 > A Rectangle Texture is a Texture that contains a single 2D image with no mipmaps. It has no power-of-two restrictions on its size. Texture coordinates for accessing this texture must be texel values (floating-point), representing texels within the texture, rather than normalized texture coordinates.
 
 Interesting restrictions but it can be useful.
-
-```
+```lisp
 CEPL> (make-texture nil :dimensions '(10 20) :element-type :uint8-vec4 :rectangle t)
 #<GL-TEXTURE-RECTANGLE (10x20)>
 ```
@@ -248,20 +226,20 @@ Cepl does not support these yet.
 
 #### Mutable and Immutable Texture Storage
 
-I was confused by this at first as I thought it was talking about the data inside the texture's gpu arrays, but no. All texture data is mutable, but OpenGL traditionally allowed you to redefine the nature of the storage on an existing texture. It also required you to do a lot more work setting up.
+I was confused by this at first, as I thought it was talking about the data inside the texture's gpu arrays -- but no. All texture data is mutable, but OpenGL traditionally allowed you to redefine the nature of the storage on an existing texture. It also required you to do a lot more work setting up.
 
-Cepl will use immutable texture storage if your GL supports it and mutable if not. Cepl will (read should) give you a texture that is ready to use (the GL term is *complete*) for details see this page: https://www.opengl.org/wiki/Texture_Storage and prepare for your brain to melt (well mine did anyway)
+CEPL will use immutable texture storage if your GL supports it and mutable if not. CEPL will (read should) give you a texture that is ready to use (the GL term is *complete*). For details see this page: https://www.opengl.org/wiki/Texture_Storage and prepare for your brain to melt (well mine did anyway).
 
 
 #### Image Formats
 
 Ok, brace yourselves...this gets hairy.
 
-Image formats dictate what dat can be stores in a texture's gpu-arrays and also how they are stored (and potentially accessed)
+Image formats dictate what data can be stored in a texture's gpu-arrays and also how it is stored (and potentially accessed).
 
 The main wiki page of Image Formats is here, https://www.opengl.org/wiki/Image_Format but I actually find that page to be missing A LOT of data, so also see this page：https://www.opengl.org/wiki/GLAPI/glTexStorage2D
 
-Yay choices. Ok so Cepl does not support all this yet. It's a shame but it doesnt. Ιt could though, so at some point I need to get back to it.
+Yay, choices. OK, so CEPL does not support all this yet. It's a shame but it doesnt. Ιt could though, so at some point I need to get back to it.
 
 Things that are defintely unsupported are:
 
@@ -273,12 +251,13 @@ Things that are in a questionable state:
 - Stencil format: I havent tested this yet.
 
 
-Auto conversion:
-Cepl can help with types by providing conversions from lisp types to their equivalent image formats.
+#### Auto conversion:
+
+CEPL can help with types by providing conversions from lisp types to their equivalent image formats.
 
 The convertable types are: `:uint8 :int8 :ushort :short :uint :int :float`
 
-Of course opengl has many more potential format that this so feel free to use any of the following formats.
+Of course OpenGL has many more potential format that this so feel free to use any of the following formats.
 
 ```
 	:r8 :r8-snorm :r16 :r16-snorm :rg8 :rg8-snorm :rg16 :rg16-snorm :rgb8
@@ -290,20 +269,20 @@ Of course opengl has many more potential format that this so feel free to use an
 	:depth-component16 :depth-component24 :depth-component32 :depth-component32f
 	:stencil-index8))
 ```
-If you are missing a format, or you are having issues with pulling or pushing data, as usual, please file an issue report on github.
+If you are missing a format, or you are having issues with pulling or pushing data, as usual, please file an (issue report on github)[https://github.com/cbaggers/cepl/issues).
 
 
 #### Pixel Formats
 
-Arghh too many format. The short version is that `pixel formats` are not equal to `image formats`. `Pixel formats` define the format of the data on the cpu side (client side in opengl terminology) and `image formats` define the gpu side.
+Arghh, too many formats. The short version is that `pixel formats` are not equal to `image formats`. `Pixel formats` define the format of the data on the cpu side (client side in OpenGL terminology) and `image formats` define the GPU side.
 
 See here for details: https://www.opengl.org/wiki/Pixel_Transfer#Format_conversion
 
-There are only certain combinations that make sense and so Cepl should just **do the right thing**. Any cases where it doesnt are considered a bug.
+There are only certain combinations that make sense and CEPL should just **do the right thing**. Any cases where it doesn't are considered a bug.
 
 
 #### Freeing
 
-You can use either `#'free` or `#'free-texture` to free textures (and all their contained gpu-arrays)
+You can use either `#'free` or `#'free-texture` to free textures (and all their contained `gpu-arrays`)
 
 You can't free a texture backed gpu-array on it's own.

--- a/docs/010 - fbos.md
+++ b/docs/010 - fbos.md
@@ -68,12 +68,12 @@ Because of this CEPL is very flexible with its `make-fbo` syntax, we will go tho
 
 Let's make one now.
 ```lisp
-(make-fbo :c)
+CEPL>(make-fbo :c)
 #<FBO COLOR-ATTACHMENTS (0)>
 ```
 This is a way of making a fbo with one color attachment. Let's make an fbo with 2 color attachments:
 ```lisp
-(make-fbo 0 1)
+CEPL>(make-fbo 0 1)
 #<FBO COLOR-ATTACHMENTS (0 1)>
 ```
 

--- a/docs/010 - fbos.md
+++ b/docs/010 - fbos.md
@@ -1,33 +1,32 @@
-# Framebuffer Objects (fbos)
+# Framebuffer Objects (FBOs)
 
-When we render in opengl, we render into a framebuffer. Framebuffers contain a number of `attachments` and these attachments are where the stuff we are rendering ends up, the logic of what ends up where will be described a little further down.
+When we render in OpenGL, we render into a framebuffer. Framebuffers contain a number of `attachments`, and these attachments are where the stuff we are rendering ends up. The logic of what ends up where will be described a little further down.
 
-We can either be rendering into the default framebuffer or a user defined one.
+We can either be rendering into the default framebuffer, or a user defined one.
 
 #### Default
 
-The Default Framebuffer is the Framebuffer that is created along with the OpenGL Context. Unlike users defined FBOs, one (usually 1) of the attachments represents what you actually see on the screen.
+The *default framebuffer* is the framebuffer that is created along with the OpenGL context. Unlike user-defined FBOs, one (well, usually one) of the attachments represents what you actually see on the screen.
 
 #### User Defined
 
-We can make our own fbos and tell Cepl to render to these instead. When we do this we don't see anything we rendered on screen but instead have the rendering result in the attachments of our fbo.
+We can make our own FBOs and tell CEPL to render to these instead. When we do this, we don't see anything we rendered on screen but instead have the rendering result in the attachments of our FBO.
 
-Why do this? Well our attachments can have texture backed gpu-arrays in them. This means we can render into a texture. Have you have ever seen a game which had 'security cam' footage on in in-game screen? Chances are they are rendering part of the world to a texture and texturing the screen with that result. Rendering to texture is useful for much more than this of course.
+Why do this? Well, our attachments can have texture backed `gpu-array`s in them. This means we can render into a texture. Have you have ever seen a game which had 'security cam' footage on an in-game screen? Chances are they are rendering part of the world to a texture, and texturing the screen with that result. Rendering to texture is useful for much more than this of course.
 
 #### Attachments
 
-Before we start making fbos we need to know a little more about attachments.
+Before we start making FBOs we need to know a little more about attachments.
 
-In Cepl attachments contain something we are rendering into and some metadata on how to render into it. Right now the only thing we put in an attachment is a texture-backed gpu-array. In the future we may support OpenGL's renderbuffer, but there are far fewer cases where this is useful (compared to rendering into a texture) so it has been ommited for now.
+In CEPL attachments contain something we are rendering into and some metadata on how to render into it. Right now, the only thing we put in an attachment is a texture-backed `gpu-array`. In the future we may support OpenGL's renderbuffer, but there are far fewer cases where this is useful (compared to rendering into a texture) so it has been ommited for now.
 
 An attachment has a certain format. It can be a `color`, `depth` or `stencil` attachment.
 
 #### Color Attachments
 
-An fbo can have **some** color attachments. The number that **some** stands for is `at least 8 but maybe more` according to OpenGL, the exact figure is defined by `:MAX_COLOR_ATTACHMENTS` (we will cover querying these values in another chapter).
+An FBO can have **some** color attachments. The number that **some** stands for is `at least 8 but maybe more` according to OpenGL, the exact figure is defined by `:MAX_COLOR_ATTACHMENTS` (we will cover querying these values in another chapter).
 
-For us a color attachment is on that holds a gpu-array with any of these image formats:
-
+For us, a color attachment is one that holds a `gpu-array` with any of these image formats:
 ```
 :r8 :r8_snorm :r16 :r16_snorm :rg8 :rg8_snorm :rg16 :rg16_snorm :r3_g3_b2 :rgb4
 :rgb5 :rgb8 :rgb8_snorm :rgb10 :rgb12 :rgb16_snorm :rgba2 :rgba4 :rgb5_a1 :rgba8
@@ -37,13 +36,13 @@ For us a color attachment is on that holds a gpu-array with any of these image f
 :rgb16i :rgb16ui :rgb32i :rgb32ui :rgba8i :rgba8ui :rgba16i :rgba16ui :rgba32i :rgba32ui
 ```
 
-Fbos are cool because you can render to multiple of these Color attachment at once.
+FBOs are cool because you can render to multiple of these color attachments at once.
 
 #### Depth Attachment
 
-You can have one depth attachment on an fbo. This means that the depth of each fragment from your fragment shader will be stored in here
+You can have one depth attachment on an FBO. This means that the depth of each fragment from your fragment shader will be stored in here.
 
-Only gpu-arrays with depth-formats are allowed to be used in this attachment. THe valid formats are
+Only `gpu-array`s with depth-formats are allowed to be used in this attachment. The valid formats are
 
 ```
 :depth-component16, :depth-component24, :depth-component32 :depth-component32f
@@ -61,33 +60,28 @@ So it's always worth having one.
 Are not supported yet, sorry
 
 
-#### Making Fbos
+#### Making FBOs
 
-Cepl really tries to ensure that you don't make an fbo that is in an invalid state. Getting those kinds of *'fbo incompleteness'* bugs is very annoying and rather easy to do in regular GL.
+CEPL really tries to ensure that you don't make an FBO that is in an invalid state. Getting those kinds of *'fbo incompleteness'* bugs is very annoying and rather easy to do in regular GL.
 
-Because of this Cepl is very flexible with its `make-fbo` syntax, we will go those the general patterns below.
+Because of this CEPL is very flexible with its `make-fbo` syntax, we will go those the general patterns below.
 
 Let's make one now.
-
-```
+```lisp
 (make-fbo :c)
 #<FBO COLOR-ATTACHMENTS (0)>
 ```
-
-This is a way of making a fbo with one color attachment. Let's make an fbo with 2 color attachments
-
-```
+This is a way of making a fbo with one color attachment. Let's make an fbo with 2 color attachments:
+```lisp
 (make-fbo 0 1)
 #<FBO COLOR-ATTACHMENTS (0 1)>
 ```
 
 How about with 2 color and 1 depth attachment
-
-```
+```lisp
 CEPL> (make-fbo 0 1 :d)
 #<FBO COLOR-ATTACHMENTS (0 1) DEPTH-ATTACHMENT T>
 ```
-
 But we didnt specify what was in the attachments. Let's have a look and see what it is.
 
 ```

--- a/docs/single-thread-swank.md
+++ b/docs/single-thread-swank.md
@@ -1,9 +1,9 @@
-# Slime and threading on Windows and OSX
+# SLIME and threading on Windows and OSX
 
-Slime by default creates a bunch of threads to help with its internal operations. This can be problematic when working with OpenGL (and thus CEPL) as compiling a `.lisp` file will run in a different thread to the thread the `REPL` runs in.
+SLIME, by default, creates a bunch of threads to help with its internal operations. This can be problematic when working with OpenGL (and thus CEPL), as compiling a `.lisp` file will run in a different thread to the thread the `REPL` runs in.
 
 Luckily `slime` can be run with different communication `styles`, including a single threaded mode.
-By default this is a little fiddly from emacs so if you add the following to your `.emacs` file:
+By default this is a little fiddly from Emacs, so if you add the following to your `.emacs` file:
 
 ```
 (require 'cl)
@@ -52,15 +52,14 @@ If you run `sbcl --load "run-session.lisp` (or the equivalent for your lisp dist
 
 You can then `slime-connect` to it as usual.
 
-
 ## Q: Why is the Windows/OSX start procedure more complicated?
 
-*A:* Both these platforms have restrictions over which thread is allowed to interact with the window manager (I will call this the 'UI thread'). This would be fine except that, when developing, most common-lisp programmers use a system like `slime` or `sly` to connect their editor to their lisp session and those systems normally run your code in a different thread.
+*A:* Both of these platforms have restrictions over which thread is allowed to interact with the window manager (I will call this the 'UI thread'). This would be fine except that, when developing, most Common Lisp programmers use a system like `slime` or `sly` to connect their editor to their Lisp session, and those systems normally run code in a different thread.
 
-The choices are then to frequently dispatch jobs to the 'UI thread' (and accept that overhead) or start `slime`/`sly` in a way that guarentees the thread. In cepl we choose the latter as, although it does add one step to starting your project, it means you can ignore the detail whilst you are working.
+The choices are then: frequently dispatch jobs to the 'UI thread' (and accept that overhead) or start `slime`/`sly` in a way that guarentees the thread. In CEPL we choose the latter as, although it does add one step to starting your project, it means you can ignore the detail whilst you are working.
 
 To get a full breakdown of the above issue run `(cepl:make-project :why)` in your repl.
 
 ## Q: I got a `symbol's function definition is void: lexical-let` error, what happened?
 
-Looks like the `cl` package wasn't required, please add `(require 'cl)` to your `.emacs` file
+Looks like the `cl` package wasn't required; please add `(require 'cl)` to your `.emacs` file


### PR DESCRIPTION
@cbaggers, I took the liberty of proofreading all the .md files (documentation and front matter) and making corrections where needed.  I think this merge will help as the documentation is a bit out of date, full of typos and sometimes just doesn't make sense.

It may be easier to just view the updated .md files [in my fork](https://github.com/stacksmith/cepl); see proofreading branch.

The fixes include:

- outright typos and linguistic issues
- outdated code in chapter 001, code now runs
- numbered callouts in chapter 001 that were not documented fully; comments in code make more sense
- all references to CEPL are capitalized, as the readme.md file introduces CEPL that way
- references to OpenGL, CFFI, Common Lisp, etc. capitalized in a consistent way
- minor sentence restructuring throughout.  I attempted to preserve a conversational tone, while streamlining the pronoun usage (we, you, etc) and changed some clumsy parts
- fixed incorrect references to chapters as they were obviously renumbered at some point
- converted some parts to tables as made sense
- cleaned up and tagged lisp examples with Lisp syntax coloring

There is more work to be done, especially with missing chapters.