### PR TITLE
Enable choosing conflicted stage name at macroexpand time

### DIFF
--- a/core/pipelines/gpu-pipeline-base.lisp
+++ b/core/pipelines/gpu-pipeline-base.lisp
@@ -121,6 +121,9 @@
   ((name :initarg :name :reader name)
    (in-arg-types :initarg :types :reader in-args)))
 
+(defmethod func-key->name ((key func-key))
+  (cons (name key) (in-args key)))
+
 (defmethod make-load-form ((key func-key) &optional environment)
    (declare (ignore environment))
    `(new-func-key ',(name key) ',(in-args key)))


### PR DESCRIPTION
def-g-> can throw errors if stage names are overloaded.

Hack in some a thing that invokes the debugger at expand time and let's
you pick the func you want.

We also change gen-recompile-func to make it's stage list from the
validated gpipe-args. This is because we can now change the stage name
using the restart

This is not pretty but I can't find another way of doing it and it was suggested by a person on the `#lisp` irc

Fixes https://github.com/cbaggers/cepl/issues/88