### PR TITLE
Added OpenGL version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All of the following will be downloaded automatically by quicklisp
 
 #### C Library dependency
 
-CEPL uses OpenGL so you need to make sure it is available on your machine. Installing your GPU drivers will usually handle this.
+CEPL uses OpenGL ( version >= 3.1 ) so you need to make sure it is available on your machine. Installing your GPU drivers will usually handle this.
 
 
 #### CEPL's Host


### PR DESCRIPTION
Made a tiny change in the readme.md section titled C library dependency. The section now includes the minimum OpenGL version number to make it obvious to those who do not meet this requirement. Not a huge change by any means, but it would have saved me some pain had it been there before.