### PR TITLE
Make cepl:quit use shutdown-function for api-1

### DIFF
--- a/core/lifecycle.lisp
+++ b/core/lifecycle.lisp
@@ -151,7 +151,7 @@
   (setf *lifecycle-state* :shutting-down)
   (call-listeners)
   ;; do shutdown stuff
-  (cepl.host:shutdown)
+  (cepl.host::%shutdown cepl.host::*current-host*)
   (setf cepl.context:*gl-context* nil)
   ;; go back to uninitialized
   (setf *lifecycle-state* :uninitialized))

--- a/host/api-0.lisp
+++ b/host/api-0.lisp
@@ -59,6 +59,10 @@
         (or *api-0-context-singleton*
             (error "CEPL Internal Bug: Must call make-window before make-context when using legacy host api")))))
 
+(defmethod %shutdown ((host api-0) &key &allow-other-keys)
+  (declare (ignore host))
+  (shutdown))
+
 (defmethod %set-surface-size ((host api-0) surface width height &key &allow-other-keys)
   (declare (ignore host surface width height))
   (warn "Setting the size of a surface is not supported when using the legacy host api"))

--- a/host/api-1.lisp
+++ b/host/api-1.lisp
@@ -186,6 +186,10 @@
              alpha-size depth-size stencil-size buffer-size
              red-size green-size blue-size)))
 
+(defmethod %shutdown ((host api-1) &key &allow-other-keys)
+  (with-slots (shutdown-function) host
+    (funcall shutdown-function)))
+
 (defmethod %set-surface-size ((host api-1) surface width height
                               &key &allow-other-keys)
   (assert surface)

--- a/host/api-generics.lisp
+++ b/host/api-generics.lisp
@@ -3,6 +3,7 @@
 (defgeneric %init (host args))
 (defgeneric %make-gl-context (host &key &allow-other-keys))
 (defgeneric %make-surface (host &rest args &key &allow-other-keys))
+(defgeneric %shutdown (host &key &allow-other-keys))
 (defgeneric %supports-multiple-surfaces-p (host &key &allow-other-keys))
 (defgeneric %supports-multiple-contexts-p (host &key &allow-other-keys))
 (defgeneric %set-surface-size (host surface width height &key &allow-other-keys))


### PR DESCRIPTION
I might be doing something backwards with the versioned api shenanigans, but this seems to work.