### PR TITLE
fix CEPL.PIPELINES::STREAM-SYMB being unbound

### DIFF
--- a/core/pipelines/defpipeline.lisp
+++ b/core/pipelines/defpipeline.lisp
@@ -624,7 +624,7 @@
    this function should only be used from another function which
    is handling the binding."
   `(let ((draw-mode ,(if (typep primitive 'varjo::dynamic)
-                         `(buffer-stream-draw-mode-val stream-symb)
+                         `(buffer-stream-draw-mode-val ,stream-symb)
                          (varjo::lisp-name primitive))))
      (handle-transform-feedback ,ctx-symb draw-mode prog-id tfs-primitive
                                 tfs-array-count)


### PR DESCRIPTION
The symbol STREAM-SYMB should be unquoted to be evaluated and replaced
by the value that is passed to DRAW-EXPANDER. This fixes the following
error:

  The variable CEPl.PIPELINES::STREAM-SYMB is unbound.