### PR TITLE
changed anisotrophy to anisotropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you are having issues getting the C libraries to load and just need to rule o
 This mainly covers features & news rather than individual bugfixes. When we are out of beta these will be covered more often
 
 ### 2019-01-20
-- Return from work crunch to add anisotrophy support to samplers :)
+- Return from work crunch to add anisotropy support to samplers :)
 
 ### 2018-09-29
 - Added support for MultiDrawIndirect using `multi-draw-g`

--- a/core/context/cepl-context.lisp
+++ b/core/context/cepl-context.lisp
@@ -282,7 +282,7 @@
         ;; {TODO} this is ugly, find a better way
         (funcall 'cepl.samplers::sampler-on-context)
         (funcall 'cepl.textures::check-immutable-feature)
-        (funcall 'cepl.samplers::check-anisotrophy-feature)
+        (funcall 'cepl.samplers::check-anisotropy-feature)
         ;;
         ;; Set the default
         (%set-default-fbo-and-viewport surface cepl-context)

--- a/core/samplers/docs.lisp
+++ b/core/samplers/docs.lisp
@@ -16,7 +16,7 @@ Sampling Parameters cover five main aspects of how the values are read:
 - Filtering
 - LOD
 - Comparison
-- Anisotrophy
+- Anisotropy
 
 We will dive into these topics below.
 
@@ -236,7 +236,7 @@ GLSL, and texture is the value fetched from the texture. So :LESS will be
 true if the reference value is strictly less than the value pulled from the
 texture.
 
-**-- Anisotrophy --*
+**-- Anisotropy --*
 
 The GL spec says the following
 
@@ -255,12 +255,12 @@ is 1f0.
 
 To set the value after creation you can use the following:
 
-    (setf (anisotrophy sampler) new-value)
+    (setf (anisotropy sampler) new-value)
 
 Where 'new-value' must be a `single-float`
 
 To get the current anisotropic filtering setting of a sampler simply pass it to
-the `anisotrophy` function.
+the `anisotropy` function.
 
 In all of the above cases a value of 1f0 means no anisotropic filtering and any
 value higher than 1f0 counts as a use of anisotropic filtering.
@@ -594,7 +594,7 @@ example:
 
 ")
 
-    (defun anisotrophy
+    (defun anisotropy
         "
 The GL spec says the following
 

--- a/core/samplers/samplers.lisp
+++ b/core/samplers/samplers.lisp
@@ -2,11 +2,11 @@
 
 ;;----------------------------------------------------------------------
 
-(defvar *anisotrophy-available* t)
+(defvar *anisotropy-available* t)
 
-(defun+ check-anisotrophy-feature ()
+(defun+ check-anisotropy-feature ()
   (unless (has-feature "GL_EXT_texture_filter_anisotropic")
-    (setf *anisotrophy-available* nil)))
+    (setf *anisotropy-available* nil)))
 
 ;;----------------------------------------------------------------------
 
@@ -241,7 +241,7 @@
       ;; from the spec:
       ;; 'Any value greater than 1.0f counts as a use of anisotropic filtering'
       ;; 1f0 is the default in the sampler
-      (%set-anisotrophy sampler-obj (coerce anisotropy 'single-float))))
+      (%set-anisotropy sampler-obj (coerce anisotropy 'single-float))))
   sampler-obj)
 
 (defmethod print-object ((object sampler) stream)
@@ -348,7 +348,7 @@
     single-float
   (unless (eql (%sampler-anisotropy sampler) value)
     (let ((sampler (note-change sampler)))
-      (%set-anisotrophy sampler value)))
+      (%set-anisotropy sampler value)))
   value)
 
 ;;----------------------------------------------------------------------
@@ -459,7 +459,7 @@
        (gl-enum :none)))
   sampler)
 
-(defn %set-anisotrophy ((sampler sampler) (value single-float))
+(defn %set-anisotropy ((sampler sampler) (value single-float))
     sampler
   (%gl::sampler-parameter-f (%cepl.types::%sampler-id sampler)
                             :texture-max-anisotropy-ext value)


### PR DESCRIPTION
This one was exceptionally mind-twisting:
`(defvar *anisotrophy-available* t)`
:)
