### PR TITLE
s/init/initalize-cepl in the docs

### DIFF
--- a/core/repl.lisp
+++ b/core/repl.lisp
@@ -72,7 +72,7 @@ It calls #'initialize-cepl to make a resizable window and prints out a message
 in the repl.
 ")
 
-  (defun init
+  (defun initialize-cepl
       "
 This is how we initialize CEPL. It is important to do this before using any api
 that touches the gpu.


### PR DESCRIPTION
The function was renamed in 8b5a0ca42c929dcbce929d6e511f4ac7fe351a3d but the docs weren't updated
