### PR TITLE
Fix failure in decode-half-float - issue 353

### DIFF
--- a/core/types/cepl-types.lisp
+++ b/core/types/cepl-types.lisp
@@ -880,7 +880,7 @@
          (significand (ldb (byte 10 0) bits)))
     (if (= exponent 31)
         (cond ((not (zerop significand))
-               (the single-float (float-features:bits-single-float -4194304)))
+               (the single-float (float-features:bits-single-float #xFFC00000)))
               ((zerop sign) single-float-positive-infinity)
               (t single-float-negative-infinity))
         (%decode-half-float bits))))


### PR DESCRIPTION
Fix failure in decode-half-float - #353

Discovered in Quicklisp report:
http://report.quicklisp.org/2021-02-07/failure-report/cepl.html

Probably appeared due to stricter type checking in SBCL