### PR TITLE
fix stride calculation on types bigger than a vec4

### DIFF
--- a/core/internals.lisp
+++ b/core/internals.lisp
@@ -26,7 +26,6 @@
                                                 (gl-type-size (second attr)))))
                                slot-layout
                                :initial-value 0)))
-          (break)
           (loop :for attr :in slot-layout
              :for i :from 0
              :with offset = 0

--- a/core/internals.lisp
+++ b/core/internals.lisp
@@ -19,9 +19,14 @@
   (let ((type (or (varjo.internals::try-type-spec->type array-type nil)
                   (error 'bad-type-for-buffer-stream-data :type array-type))))
     (if (and (varjo:core-typep type) (not (varjo:v-typep type 'v-sampler)))
-        (let ((slot-layout (cepl.types::expand-slot-to-layout
-                            nil type normalized))
-              (stride 0))
+        (let* ((slot-layout (cepl.types::expand-slot-to-layout
+                             nil type normalized))
+               (stride (reduce (lambda (accum attr)
+                                 (incf accum (* (first attr)
+                                                (gl-type-size (second attr)))))
+                               slot-layout
+                               :initial-value 0)))
+          (break)
           (loop :for attr :in slot-layout
              :for i :from 0
              :with offset = 0


### PR DESCRIPTION
If the data definition via defstruct-g or a built-in type exceeds a vec4  , the usage of `%gl:vertex-attrib-*pointer` call changes.

In CEPL, the stride was previously always 0, meaning the generic vertex attributes are tightly packed (as per the spec). The splitting of a type into multiple pointers and their offsets was already done. However, in both Fedora 37 and macOS 12.6 it gave unexpected results with vertex attributes on types that exceeded the size of a vec4.

The reason, though not documented (AFAICT), is likely due to the stride being necessary in cases for types longer than a vec4 for vertex attributes. By always providing it, we get the expected results.

The patch was tested using the following pipeline:
```
(defun-g vert ((data g-pnt)
               (instance :mat4)
               &uniform
               (view :mat4)
               (proj :mat4))
  (* proj view instance (v! (pos data) 1.0)))

(defun-g frag ()
  (vec4 1.0))

(defpipeline-g test-instancing ()
  (vert g-pnt :mat4)
  (frag))
```

Thanks for CEPL!